### PR TITLE
Don't read uninitialized memory when getting username

### DIFF
--- a/src/apps/cacheStatus/options.cpp
+++ b/src/apps/cacheStatus/options.cpp
@@ -222,7 +222,7 @@ void COptions::Init(void) {
     mode = "";
 
 #ifndef HOST_NAME_MAX
-#define HOST_NAME_MAX 64
+#define HOST_NAME_MAX 256
 #endif
 #ifndef LOGIN_NAME_MAX
 #define LOGIN_NAME_MAX 64

--- a/src/apps/cacheStatus/options.cpp
+++ b/src/apps/cacheStatus/options.cpp
@@ -223,16 +223,15 @@ void COptions::Init(void) {
 
 #ifndef HOST_NAME_MAX
 #define HOST_NAME_MAX 64
+#endif
+#ifndef LOGIN_NAME_MAX
 #define LOGIN_NAME_MAX 64
 #endif
     char hostname[HOST_NAME_MAX];
     gethostname(hostname, HOST_NAME_MAX);
-    char username[LOGIN_NAME_MAX];
-    getlogin_r(username, LOGIN_NAME_MAX);
-    if (isDockerMode()) {
-        memset(username, 0, LOGIN_NAME_MAX);
+    char username[LOGIN_NAME_MAX] = { 0 };
+    if (getlogin_r(username, LOGIN_NAME_MAX) != 0 || isDockerMode())
         strncpy(username, "nobody", 7);
-    }
 
     if (isTestMode()) {
         status.host = "--hostname-- (--username--)";

--- a/src/libs/utillib/sfos.cpp
+++ b/src/libs/utillib/sfos.cpp
@@ -303,16 +303,15 @@ bool isRunning(const string_q& progName) {
 
 #ifndef HOST_NAME_MAX
 #define HOST_NAME_MAX 64
+#endif
+#ifndef LOGIN_NAME_MAX
 #define LOGIN_NAME_MAX 64
 #endif
 //----------------------------------------------------------------------------
 string_q getUserName(void) {
-    char username[LOGIN_NAME_MAX];
-    getlogin_r(username, LOGIN_NAME_MAX);
-    if (isDockerMode()) {
-        memset(username, 0, LOGIN_NAME_MAX);
+    char username[LOGIN_NAME_MAX] = { 0 };
+    if (getlogin_r(username, LOGIN_NAME_MAX) != 0 || isDockerMode())
         strncpy(username, "nobody", 7);
-    }
     return username;
 }
 

--- a/src/libs/utillib/sfos.cpp
+++ b/src/libs/utillib/sfos.cpp
@@ -302,7 +302,7 @@ bool isRunning(const string_q& progName) {
 }
 
 #ifndef HOST_NAME_MAX
-#define HOST_NAME_MAX 64
+#define HOST_NAME_MAX 256
 #endif
 #ifndef LOGIN_NAME_MAX
 #define LOGIN_NAME_MAX 64


### PR DESCRIPTION
Fixes https://github.com/TrueBlocks/trueblocks-core/issues/1630.

---

Also defines `LOGIN_NAME_MAX` if `LOGIN_NAME_MAX` is not defined -- not if `HOST_NAME_MAX` is not defined.