### PR TITLE
Replace --keep with -k for gunzip as well (for Docker)

### DIFF
--- a/src/libs/pinlib/pinlib.cpp
+++ b/src/libs/pinlib/pinlib.cpp
@@ -332,7 +332,7 @@ bool pinlib_getChunkFromRemote(CPinnedChunk& pin, ipfsdown_t which, double sleep
 
         if (fileExists(getIndexPath(zipFile))) {
             ostringstream cmd;
-            cmd << "cd \"" << getIndexPath("") << "\" && gunzip --keep " << zipFile;
+            cmd << "cd \"" << getIndexPath("") << "\" && gunzip -k " << zipFile;
             int ret = system(cmd.str().c_str());
             // cerr << "result: " << ret << endl;
             if (ret != 0) {


### PR DESCRIPTION
Sorry, I haven't spot that we are using --keep for gunzip too. This is (again) making Docker fail