### PR TITLE
Fix arch linux build

### DIFF
--- a/src/apps/acctExport/query_flatfile.cpp
+++ b/src/apps/acctExport/query_flatfile.cpp
@@ -86,7 +86,7 @@ bool COptions::queryFlatFile(const string_q& path, bool sorted) {
     }
 
     stage.Release();
-    delete rawData;
+    free(rawData);
     rawData = NULL;
 
     return !shouldQuit();

--- a/src/libs/etherlib/node.cpp
+++ b/src/libs/etherlib/node.cpp
@@ -684,7 +684,7 @@ blknum_t getLatestBlock_client(void) {
     static blknum_t lastBlock = NOPOS;
     static timestamp_t lastTime = timestamp_t(NOPOS);
     timestamp_t thisTime = date_2_Ts(Now());
-    if (lastTime != NOPOS && thisTime < timestamp_t(lastTime + 13)) {
+    if (thisTime != timestamp_t(NOPOS) && thisTime < timestamp_t(lastTime + 13)) {
         return lastBlock;
     }
 


### PR DESCRIPTION
I fix build for the project on ArchLinux (highly likely caused by mainline compiler with additional warnings). There are two changes:

- query_flatfile.cpp - quite straightforward. I think issue cause is quite simple - mix of malloc and delete.
- node.cpp - not sure about this patch. As far as I see, previous version of if doesn't work (we compare NOPOS != NOPOS). So, there are two possible fixes: remove if statement at all or try to understand previous fix logic (it looks like there was typo 'lastTime' instead of 'thisTime'). 