### PR TITLE
Always add -j to the compilation in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ git clone -b develop git@github.com:TrueBlocks/trueblocks-core.git
 cd trueblocks-core
 mkdir build && cd build
 cmake ../src
-make
+make -j2
 ```
 
 (You may use `make -j <ncores>` to parallelize the build. Replace `<ncores>` with the number of cores on your machine.)


### PR DESCRIPTION
Reasoning is that if you don't make tries to use max cores which many
times may hurt the system, use up all the memory and start swapping.