### PR TITLE
Fixes TrueBlocks/trueblocks-core#1692: Set error exit status when tes…

### DIFF
--- a/src/other/build_assets/test-all.sh
+++ b/src/other/build_assets/test-all.sh
@@ -17,6 +17,7 @@ make generate finish
 make -j 8
 
 test-api.sh --filter all --mode both --clean --report $@
+RESULT=$?
 
 # Special case for customized customized names
 if [[ -f "$HOME/Desktop/names_custom.tab" ]]
@@ -40,3 +41,5 @@ touch "$DEST_FOLDER/names_custom.tab"
 
 cd $BUILD_FOLDER
 echo "Done..."
+
+exit $RESULT

--- a/src/other/build_assets/test-api.sh
+++ b/src/other/build_assets/test-api.sh
@@ -5,8 +5,14 @@ cd $TEST_FOLDER/gold/dev_tools/testRunner
 
 echo "Calling [testRunner $@]"
 testRunner $@ | tee $BUILD_FOLDER/results.txt
+RESULT=${PIPESTATUS[0]}
 
 cat $BUILD_FOLDER/results.txt | grep -v Skipping >x
 mv -f x $BUILD_FOLDER/results.txt
 
 cd $BUILD_FOLDER
+
+if [ $RESULT -gt 0 ]; then
+    echo "Tests failed"
+    exit 1
+fi


### PR DESCRIPTION
…ts fail

This makes testRunner exit with 1 if there were any failing tests, then carry over this exit status through test-api.sh up to test-all.sh

The change is needed for the remote execution of tests and in fact we would need it even with standard GH actions.