### PR TITLE
Add examples to API and fix formatting

### DIFF
--- a/docs/content/api/openapi.yaml
+++ b/docs/content/api/openapi.yaml
@@ -1,24 +1,6 @@
 openapi: 3.0.3
 info:
   title: TrueBlocks API
-  description: >
-   A REST layer over the TrueBlocks application. With `chifra serve`, you can
-   run this on your own machine, and make calls to local host.
-
-   ## Before you begin.  
-   * [Install the trueblocks-core application] on your machine, change your configs as needed.
-   * Run `chifra serve`
-
-    ## How to make calls
-    
-    By default, all calls are to localhost:8080. All options and flags are passed
-    through query parameters. Like the endpoints, the query parameters are exact
-    translations of the chifra cli application. These commands [have their own
-    documentation page](https://trueblocks.io/docs/chifra/introducing-chifra/).
-  
-    For detailed descriptions of fields, see [the data model reference](/data-model/intro/intro).
-  
-    ### Examples
   contact:
     email: jrush@trueblocks.io
     url: https://www.trueblocks.io
@@ -26,6 +8,63 @@ info:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
   version: 0.8.04
+  description: >
+   
+   A REST layer over the TrueBlocks application. With `chifra serve`, you can
+   run this on your own machine, and make calls to `localhost`.
+   
+   ## How to use this API
+   
+   This API's endpoints are exact translations of the commands used by the chifra
+   CLI application, and the query parameters mirror the commands' options and
+   flags. If you want details, [the commands have their own documentation page](https://trueblocks.io/docs/chifra/introducing-chifra/).
+  
+   For detailed descriptions of fields, see [the data model reference](https://trueblocks.io/data-model/intro/intro).
+
+     ### Before you begin  
+
+   1. [Install the trueblocks-core application](https://trueblocks.io/docs/prologue/installing-trueblocks/)
+     on your machine, change your configs as needed.
+   2. Run `chifra serve`
+    
+  
+     ### Example queries
+
+    By default, all calls are to `localhost:8080`.
+    All options and flags are passed through query parameters.
+
+    For example, to get block `100`, make a call to `/blocks` and specify
+    the block you want in the query parameter:
+
+    ```shell
+    curl "http://localhost:8080/blocks?blocks=100"
+    ```
+
+    Some parameters support ranges:
+
+    ```shell
+    curl "http://localhost:8080/blocks?blocks=100-120"
+    ```
+
+    Other parameters let you filter your responses. For example, to get only
+    the unique addresses from that block range:
+
+    ```shell
+    curl "http://localhost:8080/blocks?blocks=100-110&uniq=true"
+    ```
+
+    You might want to cache queries on your local machine.
+
+    ```shell
+    "http://localhost:8080/blocks?blocks=100-110&cache=true"
+    ```
+
+    Cacheing speeds up repeat queries significantly. The cache options are
+    particularly useful for calls to data-rich endpoints, like most endpoints
+    in the  "Accounts" collection.
+    
+    Of course, caches occupy local storage. So cache wisely.
+
 servers:
 - url: http://localhost:8080
   description: Local endpoints

--- a/docs/content/api/openapi.yaml
+++ b/docs/content/api/openapi.yaml
@@ -9,25 +9,25 @@ info:
     url: http://www.apache.org/licenses/LICENSE-2.0.html
   version: 0.8.04
   description: >
-   
+
    A REST layer over the TrueBlocks application. With `chifra serve`, you can
    run this on your own machine, and make calls to `localhost`.
-   
+
    ## How to use this API
-   
+
    This API's endpoints are exact translations of the commands used by the chifra
    CLI application, and the query parameters mirror the commands' options and
    flags. If you want details, [the commands have their own documentation page](https://trueblocks.io/docs/chifra/introducing-chifra/).
-  
+
    For detailed descriptions of fields, see [the data model reference](https://trueblocks.io/data-model/intro/intro).
 
-     ### Before you begin  
+     ### Before you begin
 
    1. [Install the trueblocks-core application](https://trueblocks.io/docs/prologue/installing-trueblocks/)
      on your machine, change your configs as needed.
    2. Run `chifra serve`
-    
-  
+
+
      ### Example queries
 
     By default, all calls are to `localhost:8080`.
@@ -62,7 +62,7 @@ info:
     Cacheing speeds up repeat queries significantly. The cache options are
     particularly useful for calls to data-rich endpoints, like most endpoints
     in the  "Accounts" collection.
-    
+
     Of course, caches occupy local storage. So cache wisely.
 
 servers:
@@ -602,7 +602,7 @@ paths:
             application/json:
               schema:
                 type: array
-                example:   
+                example:
                   {"data": [{
                     "tags": "50-Tokens:ERC20",
                     "address": "0xfe5f141bf94fe84bc28ded0ab966c16b17490657",
@@ -611,7 +611,7 @@ paths:
                     "source": "On chain",
                     "decimals": 18,
                     "description": "Decentralized lending infrastructure facilitating open access to credit networks on Ethereum."
-                  }]}  
+                  }]}
   /abis:
     get:
       tags:
@@ -1246,7 +1246,7 @@ paths:
           content:
             application/json:
               schema:
-                example: 
+                example:
                   {
                   "data": [
                     {
@@ -1887,11 +1887,11 @@ components:
         assetSymbol:
           description: either ETH, WEI or the symbol of the asset being reconciled as extracted from the chain
           type: string
-        decimals: 
+        decimals:
           description: Equivilent to the extracted value of getSymbol from ERC20 or, if ETH or WEI then 18
           type: number
         prevBlk:
-          description: the block number of the previous reconciliation 
+          description: the block number of the previous reconciliation
           allOf:
             - $ref: "#/components/schemas/blockNumber"
         prevBlkBal:
@@ -1913,66 +1913,66 @@ components:
         amountOut:
           description: the amount (in terms of the asset) of regular outflow during this bigint
         internalIn:
-          description: for ETH reconciliations only, the value of any internal value transfers into the accountedFor account 
-          type: number 
+          description: for ETH reconciliations only, the value of any internal value transfers into the accountedFor account
+          type: number
           format: bigint
         internalOut:
           description: for ETH reconciliations only, the value of any internal value transfers out of the accountedFor account
-          type: number 
+          type: number
           format: bigint
         selfDestructIn:
           description: for ETH reconciliations for transactions ending in self-destrution only, the value received by the accountedFor account from the self-destructed account bigint
         selfDestructOut:
-          description: for ETH reconciliations for transactions ending in self-destrution only, the value transfered out of the accountedFor account 
-          type: number 
+          description: for ETH reconciliations for transactions ending in self-destrution only, the value transfered out of the accountedFor account
+          type: number
           format: bigint
         minerBaseRewardIn:
-          description: for blocks won by the accountedFor address, this is the base fee reward for the miner 
-          type: number 
+          description: for blocks won by the accountedFor address, this is the base fee reward for the miner
+          type: number
           format: bigint
         minerNephewRewardIn:
-          description: for blocks won by the accountedFor address, this is the netphew reward for the miner 
-          type: number 
+          description: for blocks won by the accountedFor address, this is the netphew reward for the miner
+          type: number
           format: bigint
         minerTxFeeIn:
-          description: for blocks won by the accountedFor address, this is the transaction fee reward for the miner 
-          type: number 
+          description: for blocks won by the accountedFor address, this is the transaction fee reward for the miner
+          type: number
           format: bigint
         minerUncleRewardIn:
-          description: for blocks in which the accountedFor address generated an uncle, this value is the uncle reward 
-          type: number 
+          description: for blocks in which the accountedFor address generated an uncle, this value is the uncle reward
+          type: number
           format: bigint
         prefundIn:
-          description: at block zero (0) only, the amount of genesis income for the accountedFor address 
-          type: number 
+          description: at block zero (0) only, the amount of genesis income for the accountedFor address
+          type: number
           format: bigint
         gasCostOut:
-          description: if accountedFor address is the transaction’s sender (i.e. from at the top level), the amount of gas expended denominated in either ETH or WEI. 
-          type: number 
+          description: if accountedFor address is the transaction’s sender (i.e. from at the top level), the amount of gas expended denominated in either ETH or WEI.
+          type: number
           format: bigint
         endBal:
-          description: the balance of the reconciled asset at the end of this transaction found by querying the chain (see the note above about intra-block reconciliations) 
-          type: number 
+          description: the balance of the reconciled asset at the end of this transaction found by querying the chain (see the note above about intra-block reconciliations)
+          type: number
           format: bigint
         totalIn:
-          description: a calculated field -- the sum of all In fields 
-          type: number 
+          description: a calculated field -- the sum of all In fields
+          type: number
           format: bigint
         totalOut:
-          description: a calculated field -- the sum of all Out fields 
-          type: number 
+          description: a calculated field -- the sum of all Out fields
+          type: number
           format: bigint
         amountNet:
-          description: a calculated field -- totalIn - totalOut 
-          type: number 
+          description: a calculated field -- totalIn - totalOut
+          type: number
           format: bigint
         endBalCalc:
-          description: a calculated field -- begBal + amountNet 
-          type: number 
+          description: a calculated field -- begBal + amountNet
+          type: number
           format: bigint
         endBalDiff:
-          description: a calculated field -- endBal - endBalCalc, if non-zero, the reconciliation failed 
-          type: number 
+          description: a calculated field -- endBal - endBalCalc, if non-zero, the reconciliation failed
+          type: number
           format: bigint
         reconciled:
           description: a calculated field -- true if `endBal === endBalCalc` and `begBal === prevBlkBal`. `false` otherwise.
@@ -1980,8 +1980,8 @@ components:
         reconciliationType:
           description: One of regular, traces, prevdiff-partial, partial-nextdiff, or `partial-partial depending on previous, following or both transactions in the same block 	string
         spotPrice:
-          description: The price (if available) at the time of the transaction in US dollars for ETH reconciliations and ETH for other assets 
-          type: number 
+          description: The price (if available) at the time of the transaction in US dollars for ETH reconciliations and ETH for other assets
+          type: number
           format: bigint
     transactionIndex:
      example: 305
@@ -2142,7 +2142,7 @@ components:
           example: "Transfer(0xcfa5b526105ec86d893f24bc173b1d4166979f54 /*_from*/, 0xf503017d7baf7fbc0fff7492b751025c6a78179b /*_to*/, 23448922635686985718 /*_amount*/); "
     traces:
       type: object
-      properties:   
+      properties:
         blockHash:
           $ref: "#/components/schemas/hash"
         blockNumber:


### PR DESCRIPTION
First, this PR fixes the heading issue that you mentioned. It should look normal now. I also cleaned up trailing whitespace.

Second, this PR also adds example calls. If you think these look alright, I'm going to declare API documentation tasks "DONE" for now.