### PR TITLE
Bugfix/api tests not running remotely

### DIFF
--- a/src/other/build_assets/remote_testing/Dockerfile
+++ b/src/other/build_assets/remote_testing/Dockerfile
@@ -3,7 +3,8 @@ FROM golang:1.14-buster as builder
 ARG repo
 ARG commit_sha
 ARG test_target
-ARG config_file
+
+ENV TEST_TARGET=$test_target
 
 RUN apt-get update -y
 RUN apt install -y g++ gcc make cmake git nano libcurl3-dev python3 python3-dev \
@@ -21,4 +22,4 @@ RUN git clone --progress \
         cmake ../src && \
         make -j 4
 
-ENTRYPOINT bash /root/trueblocks-core/src/other/build_assets/remote_testing/build_and_test.sh $test_target
+ENTRYPOINT bash /root/trueblocks-core/src/other/build_assets/remote_testing/build_and_test.sh $TEST_TARGET

--- a/src/other/build_assets/remote_testing/build_and_test.sh
+++ b/src/other/build_assets/remote_testing/build_and_test.sh
@@ -7,6 +7,8 @@
 MAKE_TARGET="${1:-tests}"
 RUN_SERVER=false
 
+echo "Will perform $MAKE_TARGET"
+
 if [ "$MAKE_TARGET" == "test-all" ]
 then
     RUN_SERVER=true

--- a/src/other/build_assets/remote_testing/test_with_docker.sh
+++ b/src/other/build_assets/remote_testing/test_with_docker.sh
@@ -12,8 +12,9 @@ then
 fi
 
 echo "Building image..."
+
 # Build image and save its ID
-IMAGE_ID=`docker build -q --build-arg repo=$REPO --build-arg commit_sha=$COMMIT_SHA --build-arg test_target=$TEST_TARGET --build-arg config_file=$CONFIG_FILE .`
+IMAGE_ID=`docker build -q --build-arg repo=$REPO --build-arg commit_sha=$COMMIT_SHA --build-arg test_target=$TEST_TARGET .`
 
 echo "Done. Running Docker image and tests"
 # Note: we are using --rm flag, which will cause removal of the container after `docker run` exits
@@ -21,7 +22,7 @@ docker run \
     --rm \
     --network=host \
     --mount type=bind,source=/home/unchained,target=/root/unchained \
-    --mount type=bind,source=$HOME/trueBlocks.toml,target=/root/.local/share/trueblocks/trueBlocks.toml \
+    --mount type=bind,source=$CONFIG_FILE,target=/root/.local/share/trueblocks/trueBlocks.toml \
     --mount type=bind,source=$HOME/test_results/$COMMIT_SHA,target=/root/test_results \
     $IMAGE_ID
 


### PR DESCRIPTION
Fixed the bug which was causing a parameter to the scripts running remote tests to be lost before reaching `make` in the container