### PR TITLE
Bugfix/blockrange octals

### DIFF
--- a/src/apps/chifra/pkg/blockRange/parser_test.go
+++ b/src/apps/chifra/pkg/blockRange/parser_test.go
@@ -24,6 +24,22 @@ func TestParseBlockNums(t *testing.T) {
 	}
 }
 
+func TestParseBlockNumsLeading0(t *testing.T) {
+	out, err := Parse("000000-020:10")
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if out.Points[0].Block != 0 {
+		t.Error("Mismatched start block:", out.Points[0].Block)
+	}
+
+	if out.Points[1].Block != 20 {
+		t.Error("Mismatched end block:", out.Points[1].Block)
+	}
+}
+
 func TestParseBlockNumsNoEnd(t *testing.T) {
 	out, err := Parse("10:25")
 


### PR DESCRIPTION
Added support for numbers with leading zeroes as block numbers.

Before, Go would take strings like "024" as octals and convert them to decimals (resulting in 20, not 24)