### PR TITLE
Bugfix/go api errors

### DIFF
--- a/src/apps/chifra/cmd/pins/handle_list.go
+++ b/src/apps/chifra/cmd/pins/handle_list.go
@@ -53,8 +53,6 @@ func HandleList() {
 		}
 	}
 
-	var errors []string
-
 	outFmt := "%s\t%s\t%s\n"
 	switch output.Format {
 	case "txt":
@@ -64,7 +62,7 @@ func HandleList() {
 	case "json":
 		fallthrough
 	case "api":
-		err := output.PrintJson(manifestData.NewPins, errors)
+		err := output.PrintJson(manifestData.NewPins)
 		if err != nil {
 			logger.Fatal(err)
 		}

--- a/src/apps/chifra/cmd/pins_run.go
+++ b/src/apps/chifra/cmd/pins_run.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/cmd/pins"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/logger"
+	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/output"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/pinlib"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/utils"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/validate"
@@ -87,6 +88,11 @@ func validatePinsArgs(cmd *cobra.Command, args []string) error {
 }
 
 func runPins(cmd *cobra.Command, args []string) {
+	if len(validate.Errors) > 0 {
+		output.PrintJson([]string{})
+		return
+	}
+
 	err := pinlib.EstablishDirectories()
 	if err != nil {
 		if err, ok := err.(*pinlib.ErrCustomizedPath); ok {

--- a/src/apps/chifra/pkg/output/json.go
+++ b/src/apps/chifra/pkg/output/json.go
@@ -16,20 +16,32 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+
+	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/validate"
 )
 
-// PrintJson marshals its arguments and prints JSON in a standardized
-// format
-func PrintJson(serializable interface{}, errors []string) error {
-	response := map[string]interface{}{
-		"data": serializable,
-		"meta": GetMeta(),
-	}
-	if Format != "api" {
+// PrintJson marshals its arguments and prints JSON in a standardized format
+func PrintJson(serializable interface{}) error {
+	var response map[string]interface{}
+
+	if Format == "json" {
 		response = map[string]interface{}{
 			"data": serializable,
 		}
+
+	} else {
+		if len(validate.Errors) > 0 {
+			response = map[string]interface{}{
+				"errors": validate.Errors,
+			}
+		} else {
+			response = map[string]interface{}{
+				"data": serializable,
+				"meta": GetMeta(),
+			}
+		}
 	}
+
 	marshalled, err := json.MarshalIndent(response, "", "  ")
 	if err != nil {
 		return err

--- a/src/apps/chifra/pkg/validate/validate.go
+++ b/src/apps/chifra/pkg/validate/validate.go
@@ -16,7 +16,11 @@ import (
 	"errors"
 	"strconv"
 	"strings"
+
+	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/utils"
 )
+
+var Errors []string
 
 func usageEx(function, msg string, values []string) error {
 	var ret string
@@ -27,6 +31,10 @@ func usageEx(function, msg string, values []string) error {
 	for index, val := range values {
 		rep := "{" + strconv.FormatInt(int64(index), 10) + "}"
 		ret = strings.Replace(ret, rep, val, -1)
+	}
+	if utils.IsApiMode() {
+		Errors = append(Errors, ret)
+		return nil
 	}
 	return errors.New(FmtError(ret))
 }
@@ -44,6 +52,10 @@ func Deprecated(cmd string, rep string) error {
 }
 
 func FmtError(msg string) string {
+	if utils.IsApiMode() {
+		Errors = append(Errors, msg)
+		return ""
+	}
 	return "\n  " + msg + "\n"
 }
 
@@ -117,7 +129,7 @@ func ValidateEnum(field, value, valid string) error {
 	msg := "The " + field + " option ("
 	msg += value
 	msg += ") must be one of [ " + list + " ]"
-	return errors.New(FmtError(msg))
+	return Usage(msg)
 }
 
 func ValidateEnumSlice(field string, values []string, valid string) error {

--- a/src/dev_tools/testRunner/testCases/apps/pinMan.csv
+++ b/src/dev_tools/testRunner/testCases/apps/pinMan.csv
@@ -7,7 +7,7 @@ enabled ,mode ,speed ,route ,path/tool   ,filename        ,post ,options        
 #
 on      ,cmd  ,fast  ,pins  ,apps/pinMan ,help            ,n    ,@h
 on      ,cmd  ,fast  ,pins  ,apps/pinMan ,help_long       ,n    ,help
-on      ,cmd  ,fast  ,pins  ,apps/pinMan ,no_params       ,y    ,
+on      ,both ,fast  ,pins  ,apps/pinMan ,no_params       ,y    ,
 on      ,cmd  ,fast  ,pins  ,apps/pinMan ,invalid_param_1 ,y    ,junk
 on      ,both ,fast  ,pins  ,apps/pinMan ,list_local      ,y    ,list
 on      ,both ,fast  ,pins  ,apps/pinMan ,fmt_default     ,y    ,list
@@ -15,8 +15,8 @@ on      ,both ,slow  ,pins  ,apps/pinMan ,fmt_txt         ,n    ,list & fmt = tx
 on      ,both ,fast  ,pins  ,apps/pinMan ,fmt_csv         ,n    ,list & fmt = csv
 on      ,both ,fast  ,pins  ,apps/pinMan ,fmt_json        ,y    ,list & fmt = json
 on      ,both ,fast  ,pins  ,apps/pinMan ,fmt_api         ,y    ,list & fmt = api
-on      ,cmd  ,fast  ,pins  ,apps/pinMan ,fmt_junk        ,y    ,list & fmt = junk
+on      ,both ,fast  ,pins  ,apps/pinMan ,fmt_junk        ,y    ,list & fmt = junk
 local   ,both ,fast  ,pins  ,apps/pinMan ,to_file         ,y    ,list & fmt = json & to_file
-on      ,cmd  ,fast  ,pins  ,apps/pinMan ,remote_fail     ,y    ,list & remote
-on      ,cmd  ,fast  ,pins  ,apps/pinMan ,freshen_fail    ,y    ,list & freshen
-on      ,cmd  ,fast  ,pins  ,apps/pinMan ,initall_fail    ,y    ,list & init_all
+on      ,both ,fast  ,pins  ,apps/pinMan ,remote_fail     ,y    ,list & remote
+on      ,both ,fast  ,pins  ,apps/pinMan ,freshen_fail    ,y    ,list & freshen
+on      ,both ,fast  ,pins  ,apps/pinMan ,initall_fail    ,y    ,list & init_all

--- a/src/go-apps/flame-scrape/utils/utils.go
+++ b/src/go-apps/flame-scrape/utils/utils.go
@@ -38,11 +38,6 @@ func FolderExists(path string) bool {
 	return info.IsDir()
 }
 
-// IsApiMode return true if we are running in api mode
-func IsApiMode() bool {
-	return os.Getenv("API_MODE") == "true"
-}
-
 // GetParam returns a single the 'key' parameter in the URL
 func GetParam(key string, def string, r *http.Request) (string, bool) {
 	values, exists := r.URL.Query()[key]

--- a/test/gold/apps/pinMan/api_tests/pinMan_fmt_junk.txt
+++ b/test/gold/apps/pinMan/api_tests/pinMan_fmt_junk.txt
@@ -1,5 +1,5 @@
 {
   "errors": [
-    "chifra pins - The --fmt option (junk) must be one of [ json | txt | csv | api ]."
+    "The --fmt option (junk) must be one of [ json | txt | csv | api ]"
   ]
 }

--- a/test/gold/apps/pinMan/api_tests/pinMan_no_params.txt
+++ b/test/gold/apps/pinMan/api_tests/pinMan_no_params.txt
@@ -1,5 +1,5 @@
 {
   "errors": [
-    "chifra pins - Not enough arguments presented."
+    "You must choose at least one of --list or --init."
   ]
 }

--- a/test/gold/apps/pinMan/api_tests/pinMan_remote_fail.txt
+++ b/test/gold/apps/pinMan/api_tests/pinMan_remote_fail.txt
@@ -1,5 +1,5 @@
 {
   "errors": [
-    "chifra pins - You must choose at least one of --list, --init, or --freshen."
+    "The --remote flag has been deprecated."
   ]
 }


### PR DESCRIPTION
This solves the issue we discussed about returning 'errors' to the stdout when in API mode, but it's not that well done. I'm open to suggestions. It does make all but one test pass.

That test is a the special case we discussed when `cobra` handles invalid, unknown flags and doesn't give our code a chance to respond. That test is turned off with `cmd` in the mode column for `pinMan.csv`.

We discussed fixing that by moving the server code into `chifra`.

If you'd like, please review this, otherwise, please go ahead and merge it.