### PR TITLE
Removed unused --transactions flag from acctExport

### DIFF
--- a/docs/content/api/openapi.yaml
+++ b/docs/content/api/openapi.yaml
@@ -198,14 +198,6 @@ paths:
           explode: true
           schema:
             type: boolean
-        - name: transactions
-          description: export the actual transactional data (the default)
-          required: false
-          style: form
-          in: query
-          explode: true
-          schema:
-            type: boolean
         - name: receipts
           description: export receipts instead of transactional data
           required: false

--- a/src/apps/acctExport/options.cpp
+++ b/src/apps/acctExport/options.cpp
@@ -24,7 +24,6 @@ static const COption params[] = {
     COption("topics", "", "list<topic>", OPT_POSITIONAL, "filter by one or more log topics (only for --logs option)"),
     COption("fourbytes", "", "list<fourbyte>", OPT_POSITIONAL, "filter by one or more fourbytes (only for transactions and trace options)"),  // NOLINT
     COption("appearances", "p", "", OPT_SWITCH, "export a list of appearances"),
-    COption("transactions", "T", "", OPT_SWITCH, "export the actual transactional data (the default)"),
     COption("receipts", "r", "", OPT_SWITCH, "export receipts instead of transactional data"),
     COption("logs", "l", "", OPT_SWITCH, "export logs instead of transactional data"),
     COption("traces", "t", "", OPT_SWITCH, "export traces instead of transactional data"),
@@ -70,7 +69,6 @@ bool COptions::parseArguments(string_q& command) {
     // BEG_CODE_LOCAL_INIT
     CAddressArray addrs;
     CTopicArray topics;
-    bool transactions = false;
     CAddressArray emitter;
     CStringArray topic;
     bool freshen = false;
@@ -111,9 +109,6 @@ bool COptions::parseArguments(string_q& command) {
             // BEG_CODE_AUTO
         } else if (arg == "-p" || arg == "--appearances") {
             appearances = true;
-
-        } else if (arg == "-T" || arg == "--transactions") {
-            transactions = true;
 
         } else if (arg == "-r" || arg == "--receipts") {
             receipts = true;
@@ -254,7 +249,6 @@ bool COptions::parseArguments(string_q& command) {
     LOG_TEST_LIST("topics", topics, topics.empty());
     LOG_TEST_LIST("fourbytes", fourbytes, fourbytes.empty());
     LOG_TEST_BOOL("appearances", appearances);
-    LOG_TEST_BOOL("transList", transList);
     LOG_TEST_BOOL("receipts", receipts);
     LOG_TEST_BOOL("logs", logs);
     LOG_TEST_BOOL("traces", traces);

--- a/src/cmd-line-options.csv
+++ b/src/cmd-line-options.csv
@@ -4,7 +4,6 @@ num,group,tags,api_route,tool,longName,hotKey,def_val,is_required,is_customizabl
 10205,apps,Accounts,export,acctExport,topics,,,false,false,true,true,local,positional,list<topic>,filter by one or more log topics (only for --logs option)
 10207,apps,Accounts,export,acctExport,fourbytes,,,false,false,true,true,header,positional,list<fourbyte>,|filter by one or more fourbytes (only for transactions and trace options)
 10210,apps,Accounts,export,acctExport,appearances,p,,false,false,true,true,header,switch,<boolean>,export a list of appearances
-10215,apps,Accounts,export,acctExport,transactions,T,,false,false,true,true,local,switch,<boolean>,export the actual transactional data (the default)
 10220,apps,Accounts,export,acctExport,receipts,r,,false,false,true,true,header,switch,<boolean>,export receipts instead of transactional data
 10230,apps,Accounts,export,acctExport,logs,l,,false,false,true,true,header,switch,<boolean>,export logs instead of transactional data
 10240,apps,Accounts,export,acctExport,traces,t,,false,false,true,true,header,switch,<boolean>,export traces instead of transactional data


### PR DESCRIPTION
I removed the flag from `cmd-line-options.csv` and then regenerated sources. I added files that have been changed. 
The option seemed unused (just as the compiler reported)