### PR TITLE
Revert "Fixed: blocks should not be required when list_count is set"

### DIFF
--- a/src/apps/chifra/internal/blocks/validate.go
+++ b/src/apps/chifra/internal/blocks/validate.go
@@ -64,9 +64,7 @@ func (opts *BlocksOptions) ValidateBlocks() error {
 		if opts.List > 0 {
 			// Do nothing
 		} else {
-			// We check ListCount for the default value here, but what we really want is to know
-			// if it was supplied as a parameter
-			if len(opts.Blocks) == 0 && opts.ListCount == 20 {
+			if len(opts.Blocks) == 0 {
 				return validate.Usage("Please supply one or more block identifiers.")
 			}
 			if !opts.Logs && (len(opts.Emitter) > 0 || len(opts.Topic) > 0) {


### PR DESCRIPTION
Reverts TrueBlocks/trueblocks-core#1914

This actually doesn't work if the user sends in a value of 20 for list_count, so I'm reverting it.

This is a general problem with any code that has an integer for a command-line option (there are about five or six). I'll think about it and correct it for all the problem areas. We had this same issue in the C++ code which I fixed by having a sentinal to mark default and then if the user specifies anything this won't hit.