### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,7 @@
+cff-version: 1.2.0
+message: "To cite TrueBlocks in publications, please cite it as below:"
+authors:
+  - name: TrueBlocks Team
+title: "TrueBlocks: Lightweight indexing for any EVM-based blockchain"
+url: "https://trueblocks.io/"
+date-released: 2022-02-26


### PR DESCRIPTION
Type of change:
- Other

List of changes:
- Add `CITATION.cff`

Comment:
The `CITATION.cff` file allows Github to automatically generate a "Cite this repository" link in the sidebar, see the [Github docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files). This allows users to easily copy citation info. If you later write a white paper you can add its metadata to this file: [Guide to Citaion File Format](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md).

I tested to compile the `.bib` output from Github in LaTeX and it yields the following to the reference list:
TrueBlocks Team (Feb. 2022). _TrueBlocks: Lightweight indexing for any EVM-based blockchain_. url:
https://trueblocks.io/.