### PR TITLE
Artur jablonski fix/delegatecall reconciliation

### DIFF
--- a/src/libs/etherlib/reconciliation.cpp
+++ b/src/libs/etherlib/reconciliation.cpp
@@ -1018,7 +1018,7 @@ bool CReconciliation::reconcileUsingTraces(bigint_t prevEndBal, const CTransacti
                 if (trace.action.selfDestructed == acctFor)
                     selfDestructOut += trace.action.balance;
             } else {
-                if (trace.action.from == acctFor) {
+                if (trace.action.from == acctFor && !trace.isDelegateCall()) {
                     // Sometimes, EOAs appear here, but there is no way
                     // that a trace can initiate an expenditure on an EOA
                     // TODO(tjayrush): unless it's the first trace?
@@ -1029,7 +1029,7 @@ bool CReconciliation::reconcileUsingTraces(bigint_t prevEndBal, const CTransacti
                     }
                 }
 
-                if (trace.action.to == acctFor) {
+                if (trace.action.to == acctFor && !trace.isDelegateCall()) {
                     if (trans->from == "0xPrefund") {
                         prefundIn = trans->value;
                     } else if (trans->from == "0xBlockReward") {

--- a/src/libs/etherlib/trace.h
+++ b/src/libs/etherlib/trace.h
@@ -112,10 +112,6 @@ inline CTrace::~CTrace(void) {
     // EXISTING_CODE
 }
 
-inline bool CTrace::isDelegateCall(void) const {
-    return action.callType == "delegatecall";
-}
-
 //--------------------------------------------------------------------------
 inline void CTrace::clear(void) {
     // EXISTING_CODE
@@ -205,5 +201,8 @@ extern const char* STR_DISPLAY_TRACE;
 
 //---------------------------------------------------------------------------
 // EXISTING_CODE
+inline bool CTrace::isDelegateCall(void) const {
+    return action.callType == "delegatecall";
+}
 // EXISTING_CODE
 }  // namespace qblocks

--- a/src/libs/etherlib/trace.h
+++ b/src/libs/etherlib/trace.h
@@ -64,6 +64,7 @@ class CTrace : public CBaseNode {
 
     // EXISTING_CODE
     bool isErr(void) const;
+    bool isDelegateCall(void) const;
     const CTransaction* pTransaction;
     void loadTraceAsBlockReward(const CTransaction& trans, blknum_t bn, blknum_t txid);
     void loadTraceAsUncleReward(const CTransaction& trans, blknum_t bn, blknum_t uncleBn);
@@ -109,6 +110,10 @@ inline CTrace::~CTrace(void) {
     clear();
     // EXISTING_CODE
     // EXISTING_CODE
+}
+
+inline bool CTrace::isDelegateCall(void) const {
+    return action.callType == "delegatecall";
 }
 
 //--------------------------------------------------------------------------


### PR DESCRIPTION
Simple change to make sure the new code (which passes all tests) doesn't get overwrite by auto-code generator.