### PR TITLE
Update basetypes.h

### DIFF
--- a/src/libs/utillib/basetypes.h
+++ b/src/libs/utillib/basetypes.h
@@ -45,6 +45,7 @@
 #include <bitset>
 #include <mutex>  // NOLINT
 #include <dlfcn.h>
+#include <memory>
 
 //-------------------------------------------------------------------------
 using namespace std;  // NOLINT - bad practice, but it's way too late now


### PR DESCRIPTION
To resolve compilation problem for unique_ptr<> with gcc 12.1.1 on Linux