### PR TITLE
Removed code that was breaking DAppNode

### DIFF
--- a/src/apps/chifra/server/run.go
+++ b/src/apps/chifra/server/run.go
@@ -6,7 +6,6 @@ package servePkg
 
 import (
 	"log"
-	"strings"
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/colors"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/config"
@@ -24,9 +23,6 @@ func RunServe(cmd *cobra.Command, args []string) error {
 	}
 
 	apiUrl := opts.Port
-	if !strings.Contains(apiUrl, "http") {
-		apiUrl = "http://localhost" + apiUrl
-	}
 
 	chain := opts.Globals.Chain
 	configPath := config.GetPathToRootConfig()


### PR DESCRIPTION
Prefixing ports with `http://localhost` breaks DAppNode, because the package has to use `0.0.0.0` as host. This code was causing the server to listen on `http://localhost0.0.0.0:8080`. According to Go documentation, `localhost` is the default value if the host is missing, so this code was redundant.