### PR TITLE
export: remove first_record and max_records block checks

### DIFF
--- a/src/apps/acctExport/options.cpp
+++ b/src/apps/acctExport/options.cpp
@@ -137,13 +137,13 @@ bool COptions::parseArguments(string_q& command) {
             count = true;
 
         } else if (startsWith(arg, "-c:") || startsWith(arg, "--first_record:")) {
-            if (!confirmBlockNum("first_record", first_record, arg, latest))
+            if (!confirmUint("first_record", first_record, arg))
                 return false;
         } else if (arg == "-c" || arg == "--first_record") {
             return flag_required("first_record");
 
         } else if (startsWith(arg, "-e:") || startsWith(arg, "--max_records:")) {
-            if (!confirmBlockNum("max_records", max_records, arg, latest))
+            if (!confirmUint("max_records", max_records, arg))
                 return false;
         } else if (arg == "-e" || arg == "--max_records") {
             return flag_required("max_records");


### PR DESCRIPTION
first_record and max_records are not blocks and can be larger than the latest block numbers.
An example where these checks fail is trying to get the latest N records of a very active address' appearances