### PR TITLE
chifra server: fixing race condition

### DIFF
--- a/src/apps/chifra/internal/list/handle_freshen.go
+++ b/src/apps/chifra/internal/list/handle_freshen.go
@@ -167,8 +167,8 @@ func (opts *ListOptions) HandleFreshenMonitors(monitorArray *[]monitor.Monitor) 
 func (updater *MonitorUpdate) visitChunkToFreshenFinal(fileName string, resultChannel chan<- []index.AppearanceResult, wg *sync.WaitGroup) {
 	var results []index.AppearanceResult
 	defer func() {
-		wg.Done()
 		resultChannel <- results
+		wg.Done()
 	}()
 
 	// TODO: BOGUS - Should only scan if we're not already seen the block


### PR DESCRIPTION
I was getting a `panic: send on closed channel` on this channel and tracing the code back, it looks like the code [here](https://github.com/TrueBlocks/trueblocks-core/blob/master/src/apps/chifra/internal/list/handle_freshen.go#L153) is waiting on the signal to close the channel. I believe that generates a race condition because the `Done` signal is sent before the data could be sent to the channel. If the thread preempts in between and the other one closes the channel, then the data cannot be sent and it panics.

This is only a theory but I'm triggering the issue consistenly after using the api server for around an hour.