### PR TITLE
Fix: set buffersize in chifra server Scan for progress

### DIFF
--- a/src/apps/chifra/server/progress.go
+++ b/src/apps/chifra/server/progress.go
@@ -34,6 +34,8 @@ func ScanProgressLine(data []byte, atEOF bool) (advance int, token []byte, err e
 // ScanForProgress watches stderr and picks of progress messages
 func ScanForProgress(stderrPipe io.Reader, fn func(string)) {
 	scanner := bufio.NewScanner(stderrPipe)
+	buf := make([]byte, 1024*1024)
+	scanner.Buffer(buf, 1024*1024)
 	scanner.Split(ScanProgressLine)
 	for scanner.Scan() {
 		text := scanner.Text()


### PR DESCRIPTION
Fixes 'Error while reading stderr: bufio.Scanner: token too long' when exporting a block through the http api. For example block 4235012