### PR TITLE
correct potenital typo

### DIFF
--- a/src/other/migrations/README-v0.40.0.md
+++ b/src/other/migrations/README-v0.40.0.md
@@ -107,7 +107,7 @@ chifra chunks index --check
 You may see a few error reports. Regardless, run this next command:
 
 ```
-chifra index --all            # (If you've don't want all the index portions, use `chifra init` for a minimal installation.)
+chifra init --all            # (If you've don't want all the index portions, use `chifra init` for a minimal installation.)
 ```
 
 This command may take a long time. Allow it to run to completion. If it stops or you quit it, you may simply re-start it.


### PR DESCRIPTION
I think the changed line is supposed to read `init` instead of `index`, there is no `chifra index` on v40.0-beta, nor `chifra chunks index --all`, whereas there is `chifra init --all`, and later in the doc it seems to refer to this line as an initialization process.