### PR TITLE
2474 - Fix scrape crash

### DIFF
--- a/src/apps/chifra/internal/scrape/handle_scrape.go
+++ b/src/apps/chifra/internal/scrape/handle_scrape.go
@@ -78,8 +78,8 @@ func (opts *ScrapeOptions) HandleScrape() error {
 			UnripeDist:    opts.Settings.Unripe_dist,
 			RpcProvider:   config.GetRpcProvider(opts.Globals.Chain),
 			AppearanceMap: make(index.AddressAppearanceMap, opts.Settings.Apps_per_chunk),
-			TsArray:       make([]tslib.Timestamp, 0, opts.BlockCnt),
-			ProcessedMap:  make(map[int]bool, opts.BlockCnt),
+			TsArray:       make([]tslib.Timestamp, 0, origBlockCnt),
+			ProcessedMap:  make(map[int]bool, origBlockCnt),
 		}
 
 		// Remove whatever's in the unripePath before running each round. We do this

--- a/src/apps/chifra/internal/scrape/pause.go
+++ b/src/apps/chifra/internal/scrape/pause.go
@@ -7,21 +7,32 @@ import (
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/rpcClient"
 )
 
-func (opts *ScrapeOptions) Pause(progressThen *rpcClient.MetaData) {
-	// we always pause at least a quarter of a second to allow the node to 'rest'
-	time.Sleep(250 * time.Millisecond)
+const (
+	minimumSleep = time.Second / 4
+)
+
+func (opts *ScrapeOptions) Pause(progressThen *rpcClient.MetaData) <-chan time.Time {
+	sleep := opts.computePause(progressThen)
+	return time.After(sleep)
+}
+
+func (opts *ScrapeOptions) computePause(progressThen *rpcClient.MetaData) time.Duration {
+	var sleep time.Duration
+
 	isDefaultSleep := opts.Sleep >= 13 && opts.Sleep <= 14
 	distanceFromHead := progressThen.Latest - progressThen.Staging
 	shouldSleep := !isDefaultSleep || distanceFromHead <= (2*opts.Settings.Unripe_dist)
 	if shouldSleep {
-		sleep := opts.Sleep
-		if sleep > 1 {
-			logger.Log(logger.Info, "Sleeping for", sleep, "seconds -", distanceFromHead, "away from head.")
+		if opts.Sleep > 1 {
+			logger.Log(logger.Info, "Sleeping for", opts.Sleep, "seconds -", distanceFromHead, "away from head.")
 		}
-		halfSecs := (sleep * 2) - 1 // we already slept one quarter of a second
-		for i := 0; i < int(halfSecs); i++ {
-			time.Sleep(time.Duration(500) * time.Millisecond)
-		}
+		sleep = time.Duration(opts.Sleep) * time.Second
 	}
 
+	// we always pause at least a quarter of a second to allow the node to 'rest'
+	if sleep < minimumSleep {
+		sleep = minimumSleep
+	}
+
+	return sleep
 }


### PR DESCRIPTION
The fix ensure slice pre-allocation with original BlockCnt

Rework
- The `GOTO` statement is removed, and a chan timer is used to wait for next iteration.
- Inner loop for pause computation is removed
- Loggin is  enhanced, some errors was not logged.
- the `HandleScrape` still can return unexpectedly
