### PR TITLE
Added file lock for cache

### DIFF
--- a/src/apps/chifra/pkg/cache/cache.go
+++ b/src/apps/chifra/pkg/cache/cache.go
@@ -31,9 +31,9 @@ func save(chain string, filePath string, content io.Reader) (err error) {
 	fullPath := path.Join(cacheDir, filePath)
 
 	var file *os.File
-	if _, err = os.Stat(fullPath); os.IsNotExist(err) {
+	if filePkg.FileExists(fullPath) {
 		// If file doesn't exist, we don't need a lock
-		file, err = os.Create(fullPath)
+		file, err = os.OpenFile(fullPath, os.O_RDWR|os.O_CREATE, 0666)
 		if err != nil {
 			return
 		}

--- a/src/apps/chifra/pkg/cache/cache.go
+++ b/src/apps/chifra/pkg/cache/cache.go
@@ -8,6 +8,7 @@ import (
 	"path"
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/config"
+	filePkg "github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/file"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/types"
 )
 
@@ -28,9 +29,24 @@ func getCacheAndChainPath(chain string) string {
 func save(chain string, filePath string, content io.Reader) (err error) {
 	cacheDir := getCacheAndChainPath(chain)
 	fullPath := path.Join(cacheDir, filePath)
-	file, err := os.Create(fullPath)
-	if err != nil {
-		return
+
+	var file *os.File
+	if _, err = os.Stat(fullPath); os.IsNotExist(err) {
+		// If file doesn't exist, we don't need a lock
+		file, err = os.Create(fullPath)
+		if err != nil {
+			return
+		}
+		defer file.Close()
+	} else {
+		file, err = filePkg.WaitOnLock(fullPath, filePkg.DefaultOpenFlags)
+		if err != nil {
+			return
+		}
+		defer file.Close()
+		if err = filePkg.Empty(file); err != nil {
+			return
+		}
 	}
 
 	_, err = io.Copy(file, content)
@@ -38,7 +54,7 @@ func save(chain string, filePath string, content io.Reader) (err error) {
 }
 
 // load opens binary cache file for reading
-func load(chain string, filePath string) (file io.Reader, err error) {
+func load(chain string, filePath string) (file io.ReadCloser, err error) {
 	cacheDir := getCacheAndChainPath(chain)
 	fullPath := path.Join(cacheDir, filePath)
 	file, err = os.Open(fullPath)
@@ -75,12 +91,13 @@ func getItem[Data cacheable](
 	filePath string,
 	read func(w *bufio.Reader) (*Data, error),
 ) (value *Data, err error) {
-	reader, err := load(chain, filePath)
+	file, err := load(chain, filePath)
 	if err != nil {
 		return
 	}
+	defer file.Close()
 
-	bufReader := bufio.NewReader(reader)
+	bufReader := bufio.NewReader(file)
 	value, err = read(bufReader)
 	if err != nil && !os.IsNotExist(err) {
 		// Ignore the error, we will re-try next time

--- a/src/apps/chifra/pkg/file/empty.go
+++ b/src/apps/chifra/pkg/file/empty.go
@@ -1,0 +1,20 @@
+// Copyright 2021 The TrueBlocks Authors. All rights reserved.
+// Use of this source code is governed by a license that can
+// be found in the LICENSE file.
+
+package file
+
+import "os"
+
+// Empty is a shortcut function to seek to the beginning
+// of a file and truncate it to 0. It does not call
+// file.Sync though, making all operations in-memory only.
+func Empty(file *os.File) (err error) {
+	if _, err = file.Seek(0, 0); err != nil {
+		return
+	}
+	if err = file.Truncate(0); err != nil {
+		return
+	}
+	return
+}

--- a/src/apps/chifra/pkg/file/lock.go
+++ b/src/apps/chifra/pkg/file/lock.go
@@ -8,9 +8,10 @@ import (
 	"io"
 	"os"
 	"syscall"
+	"time"
 )
 
-// TODO: Why not use a mutex?
+var maxSecondsLock = 3
 
 // Lock asks the OS to lock a file for the current process
 func Lock(file *os.File) error {
@@ -48,4 +49,29 @@ func changeLock(file *os.File, lockConfig *syscall.Flock_t) error {
 	//
 	// More: https://stackoverflow.com/questions/29611352/what-is-the-difference-between-locking-with-fcntl-and-flock
 	return syscall.FcntlFlock(file.Fd(), syscall.F_SETLK, lockConfig)
+}
+
+var DefaultOpenFlags = os.O_RDWR | os.O_CREATE
+var DefaultOpenFlagsAppend = os.O_RDWR | os.O_CREATE | os.O_APPEND
+
+// WaitOnLock tries to lock a file for maximum `maxSecondsLock`
+func WaitOnLock(filePath string, openFlags int) (file *os.File, err error) {
+	file, err = os.OpenFile(filePath, openFlags, 0666)
+	if err != nil {
+		return
+	}
+
+	for i := 0; i < maxSecondsLock; i++ {
+		err = Lock(file)
+		if err == syscall.EAGAIN || err == syscall.EACCES {
+			// Another process has already locked the file, we wait
+			continue
+		}
+		if err != nil {
+			// We cannot lock, so report the error back to the caller
+			return file, err
+		}
+		time.Sleep(1 * time.Second)
+	}
+	return
 }

--- a/src/apps/chifra/pkg/file/lock.go
+++ b/src/apps/chifra/pkg/file/lock.go
@@ -5,6 +5,7 @@
 package file
 
 import (
+	"errors"
 	"io"
 	"os"
 	"syscall"
@@ -63,6 +64,9 @@ func WaitOnLock(filePath string, openFlags int) (file *os.File, err error) {
 
 	for i := 0; i < maxSecondsLock; i++ {
 		err = Lock(file)
+		if err == nil {
+			return
+		}
 		if err == syscall.EAGAIN || err == syscall.EACCES {
 			// Another process has already locked the file, we wait
 			continue
@@ -73,5 +77,5 @@ func WaitOnLock(filePath string, openFlags int) (file *os.File, err error) {
 		}
 		time.Sleep(1 * time.Second)
 	}
-	return
+	return file, errors.New("lock timeout")
 }


### PR DESCRIPTION
This is OS lock, which means it works across processes. Inside of the same process, but in different goroutines, we're covered by Go's thread-safe `os.File`.