### PR TITLE
Add newlines in subcommand --help

### DIFF
--- a/src/apps/chifra/cmd/root.go
+++ b/src/apps/chifra/cmd/root.go
@@ -71,5 +71,9 @@ Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
 
 Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
 `
-	return t + notes
+    usage := t + notes
+    if usage != "" && usage[len(usage)-1] != '\n' {
+        usage += "\n"
+    }
+	return usage
 }


### PR DESCRIPTION
Subcommands such as `chifra list -h` do not end in a newline (other than `chifra scrape -h`).

As a result, output looks like this:
```
root@d29b4aa412c4:/true/trueblocks-core/build# chifra list -h
Purpose:
  List every appearance of an address anywhere on the chain.
...
Notes:
  - No other options are permitted when --silent is selected.root@d29b4aa412c4:/true/trueblocks-core/build#
```

This pull request adds a newline to the usage output if there is not one there.

As a result, output will now look like this:
```
root@d29b4aa412c4:/true/trueblocks-core/build# chifra list -h
Purpose:
  List every appearance of an address anywhere on the chain.
...
Notes:
  - No other options are permitted when --silent is selected.
root@d29b4aa412c4:/true/trueblocks-core/build#
```