### PR TITLE
Fix GitHub action

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,7 +2,7 @@ name: BuildAndTest
 on: [pull_request, workflow_dispatch]
 jobs:
   Build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout TrueBlocks repo
         uses: actions/checkout@v2
@@ -13,7 +13,7 @@ jobs:
           go-version: "^1.18"
       - name: Install prerequistes
         run: |
-          sudo apt-get update 
+          sudo apt-get update
           sudo apt-get upgrade
           sudo apt-get install build-essential git cmake
           sudo apt-get install python3 tree jq


### PR DESCRIPTION
Our test action has been failing recently, due to (most probably) new Ubuntu image that's now `ubuntu-latest`. I think it's misconfigured and doesn't really work well with GitHub actions.

This PR makes the workflow use a specific version of Ubuntu (20.04). We can revert back to `ubuntu-latest` when this is fixed: https://github.com/orgs/community/discussions/47863