### PR TITLE
ensure staging changed before rename and removal

### DIFF
--- a/src/apps/chifra/internal/scrape/handle_scrape_consolidate.go
+++ b/src/apps/chifra/internal/scrape/handle_scrape_consolidate.go
@@ -40,10 +40,12 @@ func (opts *ScrapeOptions) HandleScrapeConsolidate(progressThen *rpcClient.MetaD
 		// we need to move the file to the end of the scraped range so we show progress
 		stageFn, _ := file.LatestFileInFolder(stageFolder) // it may not exist...
 		stageRange := base.RangeFromFilename(stageFn)
-		newRange := base.FileRange{First: stageRange.First, Last: blazeOpts.StartBlock + opts.BlockCnt - 1}
-		newFilename := filepath.Join(stageFolder, newRange.String()+".txt")
-		os.Rename(stageFn, newFilename)
-		os.Remove(stageFn) // seems redundant, but may not be on some operating systems
+		if stageRange.Last != (blazeOpts.StartBlock + opts.BlockCnt - 1) {
+			newRange := base.FileRange{First: stageRange.First, Last: blazeOpts.StartBlock + opts.BlockCnt - 1}
+			newFilename := filepath.Join(stageFolder, newRange.String()+".txt")
+			os.Rename(stageFn, newFilename)
+			os.Remove(stageFn) // seems redundant, but may not be on some operating systems
+		}
 		return true, nil
 	}
 

--- a/src/apps/chifra/internal/scrape/handle_scrape_consolidate.go
+++ b/src/apps/chifra/internal/scrape/handle_scrape_consolidate.go
@@ -40,7 +40,7 @@ func (opts *ScrapeOptions) HandleScrapeConsolidate(progressThen *rpcClient.MetaD
 		// we need to move the file to the end of the scraped range so we show progress
 		stageFn, _ := file.LatestFileInFolder(stageFolder) // it may not exist...
 		stageRange := base.RangeFromFilename(stageFn)
-		if stageRange.Last != (blazeOpts.StartBlock + opts.BlockCnt - 1) {
+		if stageRange.Last < (blazeOpts.StartBlock + opts.BlockCnt - 1) {
 			newRange := base.FileRange{First: stageRange.First, Last: blazeOpts.StartBlock + opts.BlockCnt - 1}
 			newFilename := filepath.Join(stageFolder, newRange.String()+".txt")
 			os.Rename(stageFn, newFilename)


### PR DESCRIPTION
In cases where the staging range hasn't been updated, `stageFn` and `newFilename` will be the same. The code tries to rename the file and remove the old one. Since the two have the same name, this will delete the actual staging file.
The result would be a constant re-scraping of any unfinalized block.
The fix checks if the staging range had changed before renaming and removing the old staging file

closes #2900