### PR TITLE
Bugfix/grpc names minor fixes

### DIFF
--- a/src/apps/chifra/internal/names/handle_terms_test.go
+++ b/src/apps/chifra/internal/names/handle_terms_test.go
@@ -55,18 +55,18 @@ func startServer() (*grpc.Server, *net.Listener) {
 
 var s *grpc.Server
 
-func init() {
+func setup() {
 	s, _ = startServer()
 }
 
 func BenchmarkNamesOptions_HandleTerms_Grpc(b *testing.B) {
-	b.Cleanup(func() {
-		// Remove the socket
+	b.StopTimer()
+	setup()
+	defer func() {
+		b.StopTimer()
+		s.Stop()
 		os.RemoveAll(proto.SocketAddress())
-	})
-
-	// s, _ := startServer(b.N)
-	defer s.Stop()
+	}()
 
 	buf := bytes.NewBuffer([]byte{})
 	w := bufio.NewWriter(buf)
@@ -75,6 +75,7 @@ func BenchmarkNamesOptions_HandleTerms_Grpc(b *testing.B) {
 	opts.Globals.Format = "txt"
 	opts.Globals.Writer = w
 
+	b.StartTimer()
 	err := opts.HandleTerms()
 	if err != nil {
 		b.Fatal(err)
@@ -82,6 +83,7 @@ func BenchmarkNamesOptions_HandleTerms_Grpc(b *testing.B) {
 }
 
 func BenchmarkNamesOptions_HandleTerms_CommandLine(b *testing.B) {
+	b.StopTimer()
 	buf := bytes.NewBuffer([]byte{})
 	w := bufio.NewWriter(buf)
 
@@ -89,6 +91,7 @@ func BenchmarkNamesOptions_HandleTerms_CommandLine(b *testing.B) {
 	opts.Globals.Format = "txt"
 	opts.Globals.Writer = w
 
+	b.StartTimer()
 	// Emptying in-memory cache simulates calling this code multiple times
 	// on the command line
 	names.EmptyInMemoryCache()
@@ -99,6 +102,7 @@ func BenchmarkNamesOptions_HandleTerms_CommandLine(b *testing.B) {
 }
 
 func BenchmarkNamesOptions_HandleTerms_Api(b *testing.B) {
+	b.StopTimer()
 	buf := bytes.NewBuffer([]byte{})
 	w := bufio.NewWriter(buf)
 
@@ -106,6 +110,7 @@ func BenchmarkNamesOptions_HandleTerms_Api(b *testing.B) {
 	opts.Globals.Format = "txt"
 	opts.Globals.Writer = w
 
+	b.StartTimer()
 	// Note: we are not calling names.EmptyInMemoryCache() here
 	err := opts.HandleTerms()
 	if err != nil {

--- a/src/apps/chifra/internal/names/handle_terms_test.go
+++ b/src/apps/chifra/internal/names/handle_terms_test.go
@@ -16,11 +16,10 @@ import (
 
 type chifraRpcServer struct {
 	proto.UnimplementedNamesServer
-	n int
 }
 
 func (g *chifraRpcServer) SearchStream(request *proto.SearchRequest, stream proto.Names_SearchStreamServer) error {
-	for i := 0; i < g.n; i++ {
+	for i := 0; i < 13662; i++ {
 		name := &types.SimpleName{
 			Name: fmt.Sprint(i),
 		}
@@ -32,11 +31,10 @@ func (g *chifraRpcServer) SearchStream(request *proto.SearchRequest, stream prot
 	return nil
 }
 
-func startServer(n int) (*grpc.Server, *net.Listener) {
+func startServer() (*grpc.Server, *net.Listener) {
 	rpcServer := grpc.NewServer()
 
 	stub := &chifraRpcServer{}
-	stub.n = n
 	proto.RegisterNamesServer(rpcServer, stub)
 
 	if err := os.RemoveAll(proto.SocketAddress()); err != nil {
@@ -55,13 +53,19 @@ func startServer(n int) (*grpc.Server, *net.Listener) {
 	return rpcServer, &listener
 }
 
+var s *grpc.Server
+
+func init() {
+	s, _ = startServer()
+}
+
 func BenchmarkNamesOptions_HandleTerms_Grpc(b *testing.B) {
 	b.Cleanup(func() {
 		// Remove the socket
 		os.RemoveAll(proto.SocketAddress())
 	})
 
-	s, _ := startServer(b.N)
+	// s, _ := startServer(b.N)
 	defer s.Stop()
 
 	buf := bytes.NewBuffer([]byte{})

--- a/src/apps/chifra/internal/names/handle_terms_test.go
+++ b/src/apps/chifra/internal/names/handle_terms_test.go
@@ -1,0 +1,110 @@
+package namesPkg
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/names"
+	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/types"
+	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/proto"
+	"google.golang.org/grpc"
+)
+
+type chifraRpcServer struct {
+	proto.UnimplementedNamesServer
+	n int
+}
+
+func (g *chifraRpcServer) SearchStream(request *proto.SearchRequest, stream proto.Names_SearchStreamServer) error {
+	for i := 0; i < g.n; i++ {
+		name := &types.SimpleName{
+			Name: fmt.Sprint(i),
+		}
+		if err := name.Send(stream); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func startServer(n int) (*grpc.Server, *net.Listener) {
+	rpcServer := grpc.NewServer()
+
+	stub := &chifraRpcServer{}
+	stub.n = n
+	proto.RegisterNamesServer(rpcServer, stub)
+
+	if err := os.RemoveAll(proto.SocketAddress()); err != nil {
+		panic(err)
+	}
+	listener, err := net.Listen("unix", proto.SocketAddress())
+	if err != nil {
+		panic(err)
+	}
+	go func() {
+		if err := rpcServer.Serve(listener); err != nil {
+			panic(err)
+		}
+	}()
+
+	return rpcServer, &listener
+}
+
+func BenchmarkNamesOptions_HandleTerms_Grpc(b *testing.B) {
+	b.Cleanup(func() {
+		// Remove the socket
+		os.RemoveAll(proto.SocketAddress())
+	})
+
+	s, _ := startServer(b.N)
+	defer s.Stop()
+
+	buf := bytes.NewBuffer([]byte{})
+	w := bufio.NewWriter(buf)
+
+	opts := defaultNamesOptions
+	opts.Globals.Format = "txt"
+	opts.Globals.Writer = w
+
+	err := opts.HandleTerms()
+	if err != nil {
+		b.Fatal(err)
+	}
+}
+
+func BenchmarkNamesOptions_HandleTerms_CommandLine(b *testing.B) {
+	buf := bytes.NewBuffer([]byte{})
+	w := bufio.NewWriter(buf)
+
+	opts := defaultNamesOptions
+	opts.Globals.Format = "txt"
+	opts.Globals.Writer = w
+
+	// Emptying in-memory cache simulates calling this code multiple times
+	// on the command line
+	names.EmptyInMemoryCache()
+	err := opts.HandleTerms()
+	if err != nil {
+		b.Fatal(err)
+	}
+}
+
+func BenchmarkNamesOptions_HandleTerms_Api(b *testing.B) {
+	buf := bytes.NewBuffer([]byte{})
+	w := bufio.NewWriter(buf)
+
+	opts := defaultNamesOptions
+	opts.Globals.Format = "txt"
+	opts.Globals.Writer = w
+
+	// Note: we are not calling names.EmptyInMemoryCache() here
+	err := opts.HandleTerms()
+	if err != nil {
+		b.Fatal(err)
+	}
+}

--- a/src/apps/chifra/pkg/names/names.go
+++ b/src/apps/chifra/pkg/names/names.go
@@ -105,6 +105,17 @@ func LoadNamesMap(chain string, parts Parts, terms []string) (map[base.Address]t
 	return namesMap, nil
 }
 
+// EmptyInMemoryCache removes names that are cached in-memory
+func EmptyInMemoryCache() {
+	loadedRegularNamesMutex.Lock()
+	loadedRegularNames = make(map[base.Address]types.SimpleName)
+	loadedRegularNamesMutex.Unlock()
+
+	loadedCustomNamesMutex.Lock()
+	loadedCustomNames = make(map[base.Address]types.SimpleName)
+	loadedCustomNamesMutex.Unlock()
+}
+
 var requiredColumns = []string{
 	"tags",
 	"address",

--- a/src/apps/chifra/proto/client.go
+++ b/src/apps/chifra/proto/client.go
@@ -2,16 +2,20 @@ package proto
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path"
 	"time"
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/config"
+	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/file"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
 
 const udsDefaultTimeout = 5 * time.Millisecond
+
+var ErrServerNotRunning = errors.New("gRPC server not running")
 
 func SocketAddress() string {
 	return path.Join(os.TempDir(), "trueblocks.sock")
@@ -26,6 +30,11 @@ func GetContext() (context.Context, context.CancelFunc) {
 }
 
 func Connect(ctx context.Context) (connection *grpc.ClientConn, client NamesClient, err error) {
+	if !file.FileExists(SocketAddress()) {
+		err = ErrServerNotRunning
+		return
+	}
+
 	options := []grpc.DialOption{
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithBlock(),
@@ -33,6 +42,15 @@ func Connect(ctx context.Context) (connection *grpc.ClientConn, client NamesClie
 
 	connection, err = grpc.DialContext(ctx, "unix:"+SocketAddress(), options...)
 	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			// If we got timeout, Unix Domain Socket is broken, so let's try to remove it
+			// and report back that the server is not running
+			err = os.Remove(SocketAddress())
+			if err != nil {
+				return
+			}
+			err = ErrServerNotRunning
+		}
 		return
 	}
 

--- a/test/gold/tools/ethNames/ethNames_prefund_custom_search.txt
+++ b/test/gold/tools/ethNames/ethNames_prefund_custom_search.txt
@@ -4,6 +4,7 @@ TEST[DATE|TIME] Custom:  true
 TEST[DATE|TIME] Prefund:  true
 TEST[DATE|TIME] Verbose:  true
 TEST[DATE|TIME] Format:  txt
+EROR[DATE|TIME] gRPC connection error: gRPC server not running
 tags	address	name	symbol	source	decimals	petname
 81-Custom	0x0000000000000000000000000000000000000001	Account_1	SYM_1	Testing	1	abnormally-able-ant
 80-Prefund	0x001762430ea9c3a26e5749afdb70da5f78ddbb8c	Prefund_0001		Genesis		blatantly-distinct-crow

--- a/test/gold/tools/ethNames/ethNames_simple_verbose.txt
+++ b/test/gold/tools/ethNames/ethNames_simple_verbose.txt
@@ -2,6 +2,7 @@ chifra names  etwork --verbose
 TEST[DATE|TIME] Terms:  [etwork]
 TEST[DATE|TIME] Verbose:  true
 TEST[DATE|TIME] Format:  txt
+EROR[DATE|TIME] gRPC connection error: gRPC server not running
 tags	address	name	symbol	decimals	petname
 31-Gitcoin:Grants	0x011c2c1433b36a524b548444ae2f20c015427d04	Grant 0491 - Tokamak Network: Decentralized, Scalable, Turing Complete Layer 2 Plasma			brightly-ultimate-bengal
 31-Giveth:Project	0x035495b687850f79cb1652f416ea7ec19907557c	Bees network			plainly-climbing-coral


### PR DESCRIPTION
This PR:
1. Provides better error reporting
2. Adds support for `--verbose` flag to `chifra names` (gRPC connection errors are only reported when `--verbose` is set)
3. Adds `HandleTerms` benchmarks