### PR TITLE
Fixes tests due to using totalSupply on latest block

### DIFF
--- a/src/apps/chifra/pkg/token/token_integration_test.go
+++ b/src/apps/chifra/pkg/token/token_integration_test.go
@@ -121,9 +121,9 @@ func TestGetState_NonStandard(t *testing.T) {
 		t.Fatal("wrong decimals:", token.Decimals)
 	}
 
-	if token.TotalSupply != "7069797008171168928213" {
-		t.Fatal("wrong total supply:", token.TotalSupply)
-	}
+	// if token.TotalSupply != "7069797008171168928213" {
+	// 	t.Fatal("wrong total supply:", token.TotalSupply)
+	// }
 
 	// Non-standard 2
 
@@ -152,9 +152,9 @@ func TestGetState_NonStandard(t *testing.T) {
 		t.Fatal("wrong decimals:", token.Decimals)
 	}
 
-	if token.TotalSupply != "210000000000000000000000000" {
-		t.Fatal("wrong total supply:", token.TotalSupply)
-	}
+	// if token.TotalSupply != "210000000000000000000000000" {
+	// 	t.Fatal("wrong total supply:", token.TotalSupply)
+	// }
 
 	// 3
 	nonStandard3 := base.HexToAddress("0xc4e0f3ec24972c75df7c716922096f4270b7bb4e")
@@ -183,7 +183,7 @@ func TestGetState_NonStandard(t *testing.T) {
 		t.Fatal("wrong decimals:", token.Decimals)
 	}
 
-	if token.TotalSupply != "" {
-		t.Fatal("wrong total supply:", token.TotalSupply)
-	}
+	// if token.TotalSupply != "" {
+	// 	t.Fatal("wrong total supply:", token.TotalSupply)
+	// }
 }

--- a/src/apps/chifra/pkg/token/token_integration_test.go
+++ b/src/apps/chifra/pkg/token/token_integration_test.go
@@ -53,9 +53,9 @@ func TestGetState_Erc20(t *testing.T) {
 		t.Fatal("wrong decimals:", token.Decimals)
 	}
 
-	if token.TotalSupply != "9118918230822796234900723527" {
-		t.Fatal("wrong total supply:", token.TotalSupply)
-	}
+	// if token.TotalSupply != "9118918230822796234900723527" {
+	// 	t.Fatal("wrong total supply:", token.TotalSupply)
+	// }
 }
 
 func TestGetState_Erc721(t *testing.T) {
@@ -87,9 +87,9 @@ func TestGetState_Erc721(t *testing.T) {
 		t.Fatal("NFT should not have decimals set:", token.Decimals)
 	}
 
-	if token.TotalSupply != "10000" {
-		t.Fatal("wrong total supply:", token.TotalSupply)
-	}
+	// if token.TotalSupply != "10000" {
+	// 	t.Fatal("wrong total supply:", token.TotalSupply)
+	// }
 }
 
 func TestGetState_NonStandard(t *testing.T) {


### PR DESCRIPTION
@dszlachta Just FYI. Our integration tests queried a fixed quantity for a value that changes with `latest` block. Commented out.