### PR TITLE
Bugfix/names clean reporting tests

### DIFF
--- a/src/apps/chifra/pkg/logger/logger.go
+++ b/src/apps/chifra/pkg/logger/logger.go
@@ -126,3 +126,8 @@ func Progress(tick bool, v ...any) {
 	}
 	toLog(progress, v...)
 }
+
+func CleanLine() {
+	// \033[K is escape sequence meaning "erase to end of line"
+	fmt.Print("\r\033[K")
+}

--- a/src/apps/chifra/pkg/token/token_integration_test.go
+++ b/src/apps/chifra/pkg/token/token_integration_test.go
@@ -53,9 +53,9 @@ func TestGetState_Erc20(t *testing.T) {
 		t.Fatal("wrong decimals:", token.Decimals)
 	}
 
-	// if token.TotalSupply != "9118918230822796234900723527" {
-	// 	t.Fatal("wrong total supply:", token.TotalSupply)
-	// }
+	if token.TotalSupply != "9118918230822796234900723527" {
+		t.Fatal("wrong total supply:", token.TotalSupply)
+	}
 }
 
 func TestGetState_Erc721(t *testing.T) {
@@ -87,13 +87,13 @@ func TestGetState_Erc721(t *testing.T) {
 		t.Fatal("NFT should not have decimals set:", token.Decimals)
 	}
 
-	// if token.TotalSupply != "10000" {
-	// 	t.Fatal("wrong total supply:", token.TotalSupply)
-	// }
+	if token.TotalSupply != "10000" {
+		t.Fatal("wrong total supply:", token.TotalSupply)
+	}
 }
 
 func TestGetState_NonStandard(t *testing.T) {
-	blockNumber := "latest"
+	blockNumber := "0x1036640" // 17000000
 	chain := utils.GetTestChain()
 
 	token, err := GetState(chain, nonStandard1, blockNumber)
@@ -121,9 +121,9 @@ func TestGetState_NonStandard(t *testing.T) {
 		t.Fatal("wrong decimals:", token.Decimals)
 	}
 
-	// if token.TotalSupply != "7069797008171168928213" {
-	// 	t.Fatal("wrong total supply:", token.TotalSupply)
-	// }
+	if token.TotalSupply != "7069797008171168928213" {
+		t.Fatal("wrong total supply:", token.TotalSupply)
+	}
 
 	// Non-standard 2
 
@@ -152,9 +152,9 @@ func TestGetState_NonStandard(t *testing.T) {
 		t.Fatal("wrong decimals:", token.Decimals)
 	}
 
-	// if token.TotalSupply != "210000000000000000000000000" {
-	// 	t.Fatal("wrong total supply:", token.TotalSupply)
-	// }
+	if token.TotalSupply != "210000000000000000000000000" {
+		t.Fatal("wrong total supply:", token.TotalSupply)
+	}
 
 	// 3
 	nonStandard3 := base.HexToAddress("0xc4e0f3ec24972c75df7c716922096f4270b7bb4e")
@@ -183,7 +183,7 @@ func TestGetState_NonStandard(t *testing.T) {
 		t.Fatal("wrong decimals:", token.Decimals)
 	}
 
-	// if token.TotalSupply != "" {
-	// 	t.Fatal("wrong total supply:", token.TotalSupply)
-	// }
+	if token.TotalSupply != "" {
+		t.Fatal("wrong total supply:", token.TotalSupply)
+	}
 }


### PR DESCRIPTION
This PR:
1. Fixes #2941 by properly cleaning the line after `\r` (new function to do it: `logger.CleanLine()`) and adding these messages:
```
INFO[29-05|16:26:16.522] Writing results to /Users/xxx/Library/Application Support/TrueBlocks/config/mainnet/names.tab
INFO[29-05|16:33:38.737] The regular names database was cleaned. 116 name(s) has been modified
```
2. Sets a specific block number for testing `totalSupply` in `token_integration_test.go`