### PR TITLE
Bugfix/load map is not used dup fix

### DIFF
--- a/src/apps/chifra/internal/transactions/handle_show.go
+++ b/src/apps/chifra/internal/transactions/handle_show.go
@@ -60,10 +60,8 @@ func (opts *TransactionsOptions) HandleShowTxs() (err error) {
 							if err := abi.LoadAbi(chain, address, abiMap); err != nil {
 								skipMap[address] = true
 								errorChan <- err // continue even with an error
-								// UNCOMMENT_ME
-								// } else {
-								// 	loadedMap[address] = true
-								// UNCOMMENT_ME
+							} else {
+								loadedMap[address] = true
 							}
 						}
 						arr := []*types.SimpleFunction{}

--- a/src/apps/chifra/pkg/articulate/log.go
+++ b/src/apps/chifra/pkg/articulate/log.go
@@ -14,12 +14,13 @@ func ArticulateLog(log *types.SimpleLog, abiMap abi.AbiInterfaceMap) (articulate
 	// If we couldn't, then try to find the event in `abiMap`
 	if articulated == nil {
 		selector := "0x" + hex.EncodeToString(log.Topics[0].Bytes())
-		articulated = abiMap[selector]
-	}
 
-	// If articulated is still nil, we don't have ABI for this event
-	if articulated == nil {
-		return
+		if found := abiMap[selector]; found != nil {
+			articulated = found.Clone()
+		} else {
+			// If articulated is still nil, we don't have ABI for this event
+			return
+		}
 	}
 
 	abiEvent, err := articulated.GetAbiEvent()

--- a/src/apps/chifra/pkg/types/types_function.go
+++ b/src/apps/chifra/pkg/types/types_function.go
@@ -58,6 +58,15 @@ type SimpleFunction struct {
 	// EXISTING_CODE
 }
 
+func (s *SimpleFunction) Clone() *SimpleFunction {
+	shallowCopy := *s
+	shallowCopy.Inputs = make([]SimpleParameter, len(s.Inputs))
+	shallowCopy.Outputs = make([]SimpleParameter, len(s.Outputs))
+	copy(shallowCopy.Inputs, s.Inputs)
+	copy(shallowCopy.Outputs, s.Outputs)
+	return &shallowCopy
+}
+
 func (s *SimpleFunction) Raw() *RawFunction {
 	return s.raw
 }


### PR DESCRIPTION
The code wasn't cloning SimpleFunctions stored in the map, so if we articulate a function and the next one have empty values, the previous ones were propagating