### PR TITLE
Fixes #3020

### DIFF
--- a/src/apps/chifra/pkg/abi/find.go
+++ b/src/apps/chifra/pkg/abi/find.go
@@ -19,16 +19,61 @@ const (
 func FindAbiFunction(mode FindMode, identifier string, arguments []*parser.ContractCallArgument, abis AbiInterfaceMap) (fn *types.SimpleFunction, suggestions []types.SimpleFunction, err error) {
 	for _, function := range abis {
 		function := function
-		// TODO: is this too naive?
+		// first we check if names match (or selectors, depending on mode)
 		if mode == FindByName && function.Name != identifier {
 			continue
 		}
 		if mode == FindBySelector && function.Encoding != strings.ToLower(identifier) {
 			continue
 		}
-		if arguments != nil && len(function.Inputs) != len(arguments) {
-			suggestions = append(suggestions, *function)
-			continue
+		// now we will compare arguments
+		if arguments != nil {
+			// we start with argument count
+			if len(function.Inputs) != len(arguments) {
+				suggestions = append(suggestions, *function)
+				continue
+			}
+			// now we check if the argument types are compatible
+			compatible := false
+			for index, input := range function.Inputs {
+				argument := arguments[index]
+				if input.InternalType == "string" && argument.String == nil {
+					break
+				}
+				if input.InternalType == "bool" && argument.Boolean == nil {
+					break
+				}
+				// address in parsed into argument.Hex.Address
+				if input.InternalType == "address" {
+					if argument.Hex == nil {
+						break
+					}
+					if argument.Hex.Address == nil {
+						break
+					}
+				}
+				// bytes32, array and tuples of any kind are only support via
+				// hashes. Hashes are parsed into argument.Hex.String
+				if input.InternalType == "bytes32" ||
+					strings.Contains(input.InternalType, "[") ||
+					strings.Contains(input.InternalType, "(") {
+					if argument.Hex == nil {
+						break
+					}
+					if argument.Hex.String == nil {
+						break
+					}
+				}
+				// we use strings.Contains here, because all integers are parsed into argument.Number
+				if strings.Contains(input.InternalType, "int") && argument.Number == nil {
+					break
+				}
+				compatible = true
+			}
+			if !compatible {
+				suggestions = append(suggestions, *function)
+				continue
+			}
 		}
 
 		return function, nil, nil

--- a/src/apps/chifra/pkg/parser/contract_call.go
+++ b/src/apps/chifra/pkg/parser/contract_call.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"reflect"
 	"strconv"
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/base"
@@ -66,6 +67,8 @@ type FunctionContractCall struct {
 // ContractCallArgument represents input to the smart contract method call, e.g.
 // `true` in `setSomething(true)`
 type ContractCallArgument struct {
+	Tokens []lexer.Token
+
 	String  *string             `parser:"@String"`
 	Number  *ContractCallNumber `parser:"| @Decimal"`
 	Boolean *Boolean            `parser:"| @('true'|'false')"`
@@ -94,7 +97,10 @@ func (a *ContractCallArgument) Interface() any {
 
 func (a *ContractCallArgument) AbiType(abiType *abi.Type) (any, error) {
 	if abiType.T == abi.FixedBytesTy {
-		// We only support fixed bytes as hex strings
+		// We only support fixed bytes as hashes
+		if a.Hex == nil {
+			return nil, newWrongTypeError("hash", a.Tokens[0], a.Interface())
+		}
 		hex := *a.Hex.String
 		if len(hex) == 0 {
 			return nil, errors.New("no value for fixed-size bytes argument")
@@ -108,6 +114,9 @@ func (a *ContractCallArgument) AbiType(abiType *abi.Type) (any, error) {
 	}
 
 	if abiType.T == abi.IntTy {
+		if a.Number == nil {
+			return nil, newWrongTypeError(abiType.String(), a.Tokens[0], a.Interface())
+		}
 		// We have to convert int64 to a correct int type, otherwise go-ethereum will
 		// return an error. It's not needed for uints, because they handle them differently.
 		if a.Number.Big != nil {
@@ -123,13 +132,23 @@ func (a *ContractCallArgument) AbiType(abiType *abi.Type) (any, error) {
 
 	if abiType.T == abi.AddressTy {
 		// We need go-ethereum's Address type, not ours
+		if a.Hex == nil {
+			return nil, newWrongTypeError(abiType.String(), a.Tokens[0], a.Interface())
+		}
 		address := a.Hex.Address
 		if address == nil {
-			return nil, errors.New("expected address")
+			return nil, errors.New("expected address, but got hash instead (check length)")
 		}
 
 		addressHex := common.HexToAddress(address.Hex())
 		return addressHex, nil
+	}
+
+	// Below checks are for nice errors only
+	if (abiType.T == abi.UintTy && a.Number == nil) ||
+		(abiType.T == abi.StringTy && a.String == nil) ||
+		(abiType.T == abi.BoolTy && a.Boolean == nil) {
+		return nil, newWrongTypeError(abiType.String(), a.Tokens[0], a.Interface())
 	}
 
 	return a.Interface(), nil
@@ -254,6 +273,17 @@ func (s *Selector) Capture(values []string) error {
 
 	s.Value = literal
 	return nil
+}
+
+func newWrongTypeError(expectedType string, token lexer.Token, value any) error {
+	t := reflect.TypeOf(value)
+	typeName := t.String()
+	kind := t.Kind()
+	// kinds between this range are all (u)int, called "integer" in Solidity
+	if kind > 1 && kind < 12 {
+		typeName = "integer"
+	}
+	return fmt.Errorf("expected %s, but got %s \"%s\"", expectedType, typeName, token)
 }
 
 // Build parser


### PR DESCRIPTION
Added argument compatibility check, better error messages:

```bash
# wrong first argument: string instead of address
chifra state unchainedindex.eth --call '0x7087e4bd("0xf503017d7baf7fbc0fff7492b751025c6a78179b","mainnet")'
# EROR[07-07|11:55:00.682] No ABI found for function 0x7087e4bd("0xf503017d7baf7fbc0fff7492b751025c6a78179b","mainnet")
# INFO[07-07|11:55:00.682] Did you mean:
# INFO[07-07|11:55:00.682] 1 - manifestHashMap(address,string)
```
