### PR TITLE
Fixed #3047

### DIFF
--- a/src/apps/chifra/internal/blocks/handle_show.go
+++ b/src/apps/chifra/internal/blocks/handle_show.go
@@ -15,7 +15,6 @@ import (
 )
 
 func (opts *BlocksOptions) HandleShowBlocks() error {
-	cache := opts.Globals.CacheStore(false)
 	ctx, cancel := context.WithCancel(context.Background())
 	fetchData := func(modelChan chan types.Modeler[types.RawBlock], errorChan chan error) {
 		for _, br := range opts.BlockIds {
@@ -35,11 +34,11 @@ func (opts *BlocksOptions) HandleShowBlocks() error {
 				var err error
 				if !opts.Hashes {
 					var b types.SimpleBlock[types.SimpleTransaction]
-					b, err = rpcClient.GetBlockByNumberWithTxs(opts.Globals.Chain, bn, cache)
+					b, err = rpcClient.GetBlockByNumberWithTxs(opts.Globals.Chain, bn, nil)
 					block = &b
 				} else {
 					var b types.SimpleBlock[string]
-					b, err = rpcClient.GetBlockByNumber(opts.Globals.Chain, bn, cache)
+					b, err = rpcClient.GetBlockByNumber(opts.Globals.Chain, bn, nil)
 					block = &b
 				}
 

--- a/src/apps/chifra/internal/globals/options.go
+++ b/src/apps/chifra/internal/globals/options.go
@@ -211,18 +211,15 @@ func (opts *GlobalOptions) FinishParse(args []string) {
 	}
 }
 
-// CacheStore returns cache for the given chain. If override is false, it returns
-// nil (no cache) - to ease working with command options
-func (opts *GlobalOptions) CacheStore(override bool) *cacheNew.Store {
-	if !override {
-		// User doesn't want cache
-		return nil
-	}
+// CacheStore returns cache for the given chain. If readonly is true, it returns
+// a cache that will not write new items. If nil is returned, it means "no caching"
+func (opts *GlobalOptions) CacheStore(readonly bool) *cacheNew.Store {
 	// We call NewStore, but Storer implementation (Fs by default) should decide
 	// whether it has to return a new instance or reuse the existing one
 	store, err := cacheNew.NewStore(&cacheNew.StoreOptions{
 		Location: cacheNew.FsCache,
 		Chain:    opts.Chain,
+		ReadOnly: readonly,
 	})
 	// If there was an error, we won't use the cache
 	if err != nil {

--- a/src/apps/chifra/internal/transactions/handle_show.go
+++ b/src/apps/chifra/internal/transactions/handle_show.go
@@ -16,7 +16,7 @@ import (
 func (opts *TransactionsOptions) HandleShowTxs() (err error) {
 	abiCache := articulate.NewAbiCache()
 	chain := opts.Globals.Chain
-	cache := opts.Globals.CacheStore(false)
+	cache := opts.Globals.CacheStore(!opts.Cache)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	fetchData := func(modelChan chan types.Modeler[types.RawTransaction], errorChan chan error) {

--- a/src/apps/chifra/internal/transactions/handle_show.go
+++ b/src/apps/chifra/internal/transactions/handle_show.go
@@ -16,7 +16,6 @@ import (
 func (opts *TransactionsOptions) HandleShowTxs() (err error) {
 	abiCache := articulate.NewAbiCache()
 	chain := opts.Globals.Chain
-	cache := opts.Globals.CacheStore(!opts.Cache)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	fetchData := func(modelChan chan types.Modeler[types.RawTransaction], errorChan chan error) {
@@ -28,7 +27,7 @@ func (opts *TransactionsOptions) HandleShowTxs() (err error) {
 			}
 
 			for _, appearance := range txIds {
-				tx, err := rpcClient.GetTransactionByAppearance(chain, &appearance, opts.Traces, cache)
+				tx, err := rpcClient.GetTransactionByAppearance(chain, &appearance, opts.Traces, nil)
 				if err != nil {
 					errorChan <- fmt.Errorf("transaction at %s returned an error: %w", strings.Replace(rng.Orig, "-", ".", -1), err)
 					continue

--- a/src/apps/chifra/pkg/cacheNew/cache_new.go
+++ b/src/apps/chifra/pkg/cacheNew/cache_new.go
@@ -50,8 +50,12 @@ type Marshaler interface {
 type StoreOptions struct {
 	Location StoreLocation
 	Chain    string
+
 	// Optional
+
 	RootDir string
+	// If ReadOnly is true, then we will not write to the cache
+	ReadOnly bool
 }
 
 func (s *StoreOptions) location() (loc Storer, err error) {


### PR DESCRIPTION
This PR adds a new option to cache Store: `readOnly bool`. Read-only cache will always read items, but never write them. 
If `Write` is called, then a new error `ErrReadOnly` is returned. Cache errors are usually ignored, so it's OK. But it will show up when debugging with `CACHE_VERBOSE=true`.

Because the new cache is disabled by default, in order to test the changes one needs to add 
`cache := opts.Globals.CacheStore(!opts.Cache)` to e.g. `transactions/handle_show.go`