### PR TITLE
Removed calls to slow utils.FormattedDate in UnmarshalCache

### DIFF
--- a/src/apps/chifra/pkg/types/types_log.go
+++ b/src/apps/chifra/pkg/types/types_log.go
@@ -246,10 +246,6 @@ func (s *SimpleLog) UnmarshalCache(version uint64, reader io.Reader) (err error)
 		return err
 	}
 
-	if s.Timestamp > 0 {
-		s.Date = utils.FormattedDate(s.Timestamp)
-	}
-
 	return
 }
 

--- a/src/apps/chifra/pkg/types/types_transaction.go
+++ b/src/apps/chifra/pkg/types/types_transaction.go
@@ -470,8 +470,6 @@ func (s *SimpleTransaction) UnmarshalCache(version uint64, reader io.Reader) (er
 	}
 	s.Receipt = optReceipt.Get()
 
-	s.Date = utils.FormattedDate(s.Timestamp)
-
 	return
 }
 


### PR DESCRIPTION
There's `Date` field in `SimpleTransaction`. When I was finishing cache, I've added parsing it to `SimpleTransaction.UnmarshalCache` by a mistake. It turns out to be slow in this case.