### PR TITLE
Surrounds handler code with a timer for performance testing

### DIFF
--- a/src/apps/chifra/internal/abis/output.go
+++ b/src/apps/chifra/internal/abis/output.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/internal/globals"
+	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/logger"
 	outputHelpers "github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/output/helpers"
 	"github.com/spf13/cobra"
 )
@@ -49,6 +50,8 @@ func (opts *AbisOptions) AbisInternal() (err error, handled bool) {
 		return err, true
 	}
 
+	timer := logger.NewTimer()
+	msg := "chifra abis"
 	// EXISTING_CODE
 	handled = true
 	if len(opts.Find) > 0 {
@@ -61,6 +64,7 @@ func (opts *AbisOptions) AbisInternal() (err error, handled bool) {
 		err = opts.HandleAddresses()
 	}
 	// EXISTING_CODE
+	timer.Report(msg)
 
 	return
 }

--- a/src/apps/chifra/internal/blocks/output.go
+++ b/src/apps/chifra/internal/blocks/output.go
@@ -50,6 +50,8 @@ func (opts *BlocksOptions) BlocksInternal() (err error, handled bool) {
 		return err, true
 	}
 
+	timer := logger.NewTimer()
+	msg := "chifra blocks"
 	// EXISTING_CODE
 	if !opts.IsPorted() {
 		logger.Fatal("Should not happen in BlocksInternal")
@@ -81,6 +83,7 @@ func (opts *BlocksOptions) BlocksInternal() (err error, handled bool) {
 		err = opts.HandleShowBlocks()
 	}
 	// EXISTING_CODE
+	timer.Report(msg)
 
 	return
 }

--- a/src/apps/chifra/internal/chunks/output.go
+++ b/src/apps/chifra/internal/chunks/output.go
@@ -54,6 +54,8 @@ func (opts *ChunksOptions) ChunksInternal() (err error, handled bool) {
 		return err, true
 	}
 
+	timer := logger.NewTimer()
+	msg := "chifra chunks"
 	// EXISTING_CODE
 	if !opts.IsPorted() {
 		logger.Fatal("Should not happen in NamesInternal")
@@ -103,6 +105,7 @@ func (opts *ChunksOptions) ChunksInternal() (err error, handled bool) {
 		}
 	}
 	// EXISTING_CODE
+	timer.Report(msg)
 
 	return
 }

--- a/src/apps/chifra/internal/config/output.go
+++ b/src/apps/chifra/internal/config/output.go
@@ -50,6 +50,8 @@ func (opts *ConfigOptions) ConfigInternal() (err error, handled bool) {
 		return err, true
 	}
 
+	timer := logger.NewTimer()
+	msg := "chifra config"
 	// EXISTING_CODE
 	if !opts.IsPorted() {
 		logger.Fatal("Should not happen.")
@@ -62,6 +64,7 @@ func (opts *ConfigOptions) ConfigInternal() (err error, handled bool) {
 		logger.Warn("The config tool is current unavailable. Please use the 'chifra status' tool instead.")
 	}
 	// EXISTING_CODE
+	timer.Report(msg)
 
 	return
 }

--- a/src/apps/chifra/internal/daemon/output.go
+++ b/src/apps/chifra/internal/daemon/output.go
@@ -57,6 +57,8 @@ func (opts *DaemonOptions) DaemonInternal() (err error, handled bool) {
 		return err, true
 	}
 
+	timer := logger.NewTimer()
+	msg := "chifra daemon"
 	// EXISTING_CODE
 	if !opts.IsPorted() {
 		logger.Fatal("Should not happen in DaemonInternal")
@@ -97,6 +99,7 @@ func (opts *DaemonOptions) DaemonInternal() (err error, handled bool) {
 	logger.Fatal(http.ListenAndServe(opts.Port, NewRouter()))
 
 	// EXISTING_CODE
+	timer.Report(msg)
 
 	return
 }

--- a/src/apps/chifra/internal/explore/output.go
+++ b/src/apps/chifra/internal/explore/output.go
@@ -55,6 +55,8 @@ func (opts *ExploreOptions) ExploreInternal() (err error, handled bool) {
 		return err, true
 	}
 
+	timer := logger.NewTimer()
+	msg := "chifra explore"
 	// EXISTING_CODE
 	if !opts.IsPorted() {
 		logger.Fatal("Should not happen in ExploreInternal")
@@ -73,6 +75,7 @@ func (opts *ExploreOptions) ExploreInternal() (err error, handled bool) {
 		}
 	}
 	// EXISTING_CODE
+	timer.Report(msg)
 
 	return
 }

--- a/src/apps/chifra/internal/export/output.go
+++ b/src/apps/chifra/internal/export/output.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/internal/globals"
+	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/logger"
 	outputHelpers "github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/output/helpers"
 	"github.com/spf13/cobra"
 )
@@ -49,6 +50,8 @@ func (opts *ExportOptions) ExportInternal() (err error, handled bool) {
 		return err, true
 	}
 
+	timer := logger.NewTimer()
+	msg := "chifra export"
 	// EXISTING_CODE
 	_, err = opts.FreshenMonitorsForExport()
 	if err != nil {
@@ -63,6 +66,7 @@ func (opts *ExportOptions) ExportInternal() (err error, handled bool) {
 	handled = true
 	err = opts.Globals.PassItOn("acctExport", opts.Globals.Chain, opts.toCmdLine(), opts.getEnvStr())
 	// EXISTING_CODE
+	timer.Report(msg)
 
 	return
 }

--- a/src/apps/chifra/internal/init/output.go
+++ b/src/apps/chifra/internal/init/output.go
@@ -50,6 +50,8 @@ func (opts *InitOptions) InitInternal() (err error, handled bool) {
 		return err, true
 	}
 
+	timer := logger.NewTimer()
+	msg := "chifra init"
 	// EXISTING_CODE
 	if !opts.IsPorted() {
 		logger.Fatal("Should not happen in InitInternal")
@@ -63,6 +65,7 @@ func (opts *InitOptions) InitInternal() (err error, handled bool) {
 		err = opts.HandleInit()
 	}
 	// EXISTING_CODE
+	timer.Report(msg)
 
 	return
 }

--- a/src/apps/chifra/internal/list/output.go
+++ b/src/apps/chifra/internal/list/output.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/internal/globals"
+	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/logger"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/monitor"
 	outputHelpers "github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/output/helpers"
 	"github.com/spf13/cobra"
@@ -50,6 +51,8 @@ func (opts *ListOptions) ListInternal() (err error, handled bool) {
 		return err, true
 	}
 
+	timer := logger.NewTimer()
+	msg := "chifra list"
 	// EXISTING_CODE
 	handled = true // everything is handled even on failure
 
@@ -71,6 +74,7 @@ func (opts *ListOptions) ListInternal() (err error, handled bool) {
 		}
 	}
 	// EXISTING_CODE
+	timer.Report(msg)
 
 	return
 }

--- a/src/apps/chifra/internal/logs/output.go
+++ b/src/apps/chifra/internal/logs/output.go
@@ -50,6 +50,8 @@ func (opts *LogsOptions) LogsInternal() (err error, handled bool) {
 		return err, true
 	}
 
+	timer := logger.NewTimer()
+	msg := "chifra logs"
 	// EXISTING_CODE
 	if !opts.IsPorted() {
 		logger.Panic("Should not happen in chifra logs.")
@@ -58,6 +60,7 @@ func (opts *LogsOptions) LogsInternal() (err error, handled bool) {
 	handled = true
 	err = opts.HandleShowLogs()
 	// EXISTING_CODE
+	timer.Report(msg)
 
 	return
 }

--- a/src/apps/chifra/internal/monitors/output.go
+++ b/src/apps/chifra/internal/monitors/output.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/internal/globals"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/colors"
+	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/logger"
 	outputHelpers "github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/output/helpers"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/validate"
 	"github.com/spf13/cobra"
@@ -69,6 +70,8 @@ func (opts *MonitorsOptions) MonitorsInternal() (err error, handled bool) {
 		return err, true
 	}
 
+	timer := logger.NewTimer()
+	msg := "chifra monitors"
 	// EXISTING_CODE
 	handled = true // everything is handled even on failure
 
@@ -97,6 +100,7 @@ func (opts *MonitorsOptions) MonitorsInternal() (err error, handled bool) {
 
 	}
 	// EXISTING_CODE
+	timer.Report(msg)
 
 	return
 }

--- a/src/apps/chifra/internal/names/output.go
+++ b/src/apps/chifra/internal/names/output.go
@@ -60,6 +60,8 @@ func (opts *NamesOptions) NamesInternal() (err error, handled bool) {
 		return err, true
 	}
 
+	timer := logger.NewTimer()
+	msg := "chifra names"
 	// EXISTING_CODE
 	if !opts.IsPorted() {
 		logger.Fatal("Should not happen in NamesInternal")
@@ -79,6 +81,7 @@ func (opts *NamesOptions) NamesInternal() (err error, handled bool) {
 	}
 
 	// EXISTING_CODE
+	timer.Report(msg)
 
 	return
 }

--- a/src/apps/chifra/internal/receipts/output.go
+++ b/src/apps/chifra/internal/receipts/output.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/internal/globals"
+	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/logger"
 	outputHelpers "github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/output/helpers"
 	"github.com/spf13/cobra"
 )
@@ -49,10 +50,13 @@ func (opts *ReceiptsOptions) ReceiptsInternal() (err error, handled bool) {
 		return err, true
 	}
 
+	timer := logger.NewTimer()
+	msg := "chifra receipts"
 	// EXISTING_CODE
 	handled = true
 	err = opts.HandleShowReceipts()
 	// EXISTING_CODE
+	timer.Report(msg)
 
 	return
 }

--- a/src/apps/chifra/internal/scrape/output.go
+++ b/src/apps/chifra/internal/scrape/output.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/internal/globals"
+	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/logger"
 	outputHelpers "github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/output/helpers"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/validate"
 
@@ -51,6 +52,8 @@ func (opts *ScrapeOptions) ScrapeInternal() (err error, handled bool) {
 		return err, true
 	}
 
+	timer := logger.NewTimer()
+	msg := "chifra scrape"
 	// EXISTING_CODE
 	if opts.Globals.IsApiMode() {
 		return validate.Usage("chifra scrape is not available in API mode"), true
@@ -59,6 +62,7 @@ func (opts *ScrapeOptions) ScrapeInternal() (err error, handled bool) {
 	handled = true
 	err = opts.HandleScrape() // Note this never returns
 	// EXISTING_CODE
+	timer.Report(msg)
 
 	return
 }

--- a/src/apps/chifra/internal/slurp/output.go
+++ b/src/apps/chifra/internal/slurp/output.go
@@ -50,6 +50,8 @@ func (opts *SlurpOptions) SlurpInternal() (err error, handled bool) {
 		return err, true
 	}
 
+	timer := logger.NewTimer()
+	msg := "chifra slurp"
 	// EXISTING_CODE
 	if !opts.IsPorted() {
 		logger.Fatal("Should not happen.")
@@ -62,6 +64,7 @@ func (opts *SlurpOptions) SlurpInternal() (err error, handled bool) {
 		err = opts.HandleShowSlurps()
 	}
 	// EXISTING_CODE
+	timer.Report(msg)
 
 	return
 }

--- a/src/apps/chifra/internal/state/output.go
+++ b/src/apps/chifra/internal/state/output.go
@@ -50,6 +50,8 @@ func (opts *StateOptions) StateInternal() (err error, handled bool) {
 		return err, true
 	}
 
+	timer := logger.NewTimer()
+	msg := "chifra state"
 	// EXISTING_CODE
 	if !opts.IsPorted() {
 		logger.Fatal("Should not happen in StateInternal")
@@ -62,6 +64,7 @@ func (opts *StateOptions) StateInternal() (err error, handled bool) {
 		err = opts.HandleShow()
 	}
 	// EXISTING_CODE
+	timer.Report(msg)
 
 	return
 }

--- a/src/apps/chifra/internal/status/output.go
+++ b/src/apps/chifra/internal/status/output.go
@@ -50,6 +50,8 @@ func (opts *StatusOptions) StatusInternal() (err error, handled bool) {
 		return err, true
 	}
 
+	timer := logger.NewTimer()
+	msg := "chifra status"
 	// EXISTING_CODE
 	if !opts.IsPorted() {
 		logger.Fatal("Should not happen in NamesInternal")
@@ -62,6 +64,7 @@ func (opts *StatusOptions) StatusInternal() (err error, handled bool) {
 		err = opts.HandleStatusTerse()
 	}
 	// EXISTING_CODE
+	timer.Report(msg)
 
 	return
 }

--- a/src/apps/chifra/internal/tokens/output.go
+++ b/src/apps/chifra/internal/tokens/output.go
@@ -50,6 +50,8 @@ func (opts *TokensOptions) TokensInternal() (err error, handled bool) {
 		return err, true
 	}
 
+	timer := logger.NewTimer()
+	msg := "chifra tokens"
 	// EXISTING_CODE
 	if !opts.IsPorted() {
 		logger.Fatal("Should not happen in StateInternal")
@@ -62,6 +64,7 @@ func (opts *TokensOptions) TokensInternal() (err error, handled bool) {
 		err = opts.HandleShow()
 	}
 	// EXISTING_CODE
+	timer.Report(msg)
 
 	return
 }

--- a/src/apps/chifra/internal/traces/output.go
+++ b/src/apps/chifra/internal/traces/output.go
@@ -50,6 +50,8 @@ func (opts *TracesOptions) TracesInternal() (err error, handled bool) {
 		return err, true
 	}
 
+	timer := logger.NewTimer()
+	msg := "chifra traces"
 	// EXISTING_CODE
 	if !opts.IsPorted() {
 		logger.Fatal("Should never happen")
@@ -64,6 +66,7 @@ func (opts *TracesOptions) TracesInternal() (err error, handled bool) {
 		err = opts.HandleShowTraces()
 	}
 	// EXISTING_CODE
+	timer.Report(msg)
 
 	return
 }

--- a/src/apps/chifra/internal/transactions/output.go
+++ b/src/apps/chifra/internal/transactions/output.go
@@ -50,6 +50,8 @@ func (opts *TransactionsOptions) TransactionsInternal() (err error, handled bool
 		return err, true
 	}
 
+	timer := logger.NewTimer()
+	msg := "chifra transactions"
 	// EXISTING_CODE
 	if !opts.IsPorted() {
 		logger.Fatal("Should never happen")
@@ -75,6 +77,7 @@ func (opts *TransactionsOptions) TransactionsInternal() (err error, handled bool
 		err = opts.HandleShowTxs()
 	}
 	// EXISTING_CODE
+	timer.Report(msg)
 
 	return
 }

--- a/src/apps/chifra/internal/when/output.go
+++ b/src/apps/chifra/internal/when/output.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/internal/globals"
+	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/logger"
 	outputHelpers "github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/output/helpers"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/utils"
 	"github.com/spf13/cobra"
@@ -50,6 +51,8 @@ func (opts *WhenOptions) WhenInternal() (err error, handled bool) {
 		return err, true
 	}
 
+	timer := logger.NewTimer()
+	msg := "chifra when"
 	// EXISTING_CODE
 	// TODO: This should use StreamMany for all cases
 	handled = true
@@ -84,6 +87,7 @@ func (opts *WhenOptions) WhenInternal() (err error, handled bool) {
 		err = opts.HandleShowBlocks()
 	}
 	// EXISTING_CODE
+	timer.Report(msg)
 
 	return
 }

--- a/src/apps/chifra/pkg/logger/timer.go
+++ b/src/apps/chifra/pkg/logger/timer.go
@@ -1,0 +1,37 @@
+package logger
+
+import (
+	"os"
+	"strings"
+	"time"
+)
+
+var perfTiming bool
+
+func init() {
+	perfTiming = os.Getenv("TB_TIMER_ON") == "true"
+}
+
+type Timer struct {
+	start   time.Time
+	verbose bool
+}
+
+func NewTimer() Timer {
+	return Timer{
+		start:   time.Now(),
+		verbose: false,
+	}
+}
+
+func (t Timer) Report(msg string) {
+	if !perfTiming {
+		return
+	}
+	since := time.Since(t.start)
+	if t.verbose {
+		Info(msg, "start", t.start)
+		Info(msg, "stop", time.Now())
+	}
+	Info(msg+" timer:", since.Milliseconds(), "ms", strings.Repeat(" ", 80))
+}

--- a/src/dev_tools/makeClass/templates/blank_output.go.tmpl
+++ b/src/dev_tools/makeClass/templates/blank_output.go.tmpl
@@ -41,8 +41,11 @@ func (opts *[{PROPER}]Options) [{PROPER}]Internal() (err error, handled bool) {
 		return err, true
 	}
 
+	timer := logger.NewTimer()
+	msg := "chifra [{ROUTE}]"
 	// EXISTING_CODE
 	// EXISTING_CODE
+	timer.Report(msg)
 
 	return
 }


### PR DESCRIPTION
This PR surrounds the handler code for each tool with a very simple performance timer. It's not perfect, but it will help me make testing scripts. It's auto-generated, so very easy to remove or modify.