### PR TITLE
Post merge cleanup

### DIFF
--- a/src/apps/chifra/internal/blocks/handle_count.go
+++ b/src/apps/chifra/internal/blocks/handle_count.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/cacheNew"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/index"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/output"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/rpc"
@@ -36,7 +37,7 @@ func (opts *BlocksOptions) HandleCounts() error {
 
 			for _, bn := range blockNums {
 				var block types.SimpleBlock[string]
-				if block, err = rpcClient.GetBlockByNumber(chain, bn, nil); err != nil {
+				if block, err = rpcClient.GetBlockByNumber(chain, bn, cacheNew.NoCache); err != nil {
 					errorChan <- err
 					if errors.Is(err, ethereum.NotFound) {
 						continue

--- a/src/apps/chifra/internal/blocks/handle_decache.go
+++ b/src/apps/chifra/internal/blocks/handle_decache.go
@@ -71,6 +71,7 @@ func (opts *BlocksOptions) HandleDecache() error {
 
 	return nil
 
+	// TODO: Review then remove
 	// pairs := []base.NumPair[uint32]{}
 	// for _, br := range opts.BlockIds {
 	// 	blockNums, err := br.ResolveBlocks(opts.Globals.Chain)

--- a/src/apps/chifra/internal/blocks/handle_list.go
+++ b/src/apps/chifra/internal/blocks/handle_list.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/cacheNew"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/output"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/rpcClient"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/types"
@@ -32,7 +33,7 @@ func (opts *BlocksOptions) HandleList() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	fetchData := func(modelChan chan types.Modeler[types.RawBlock], errorChan chan error) {
 		for bn := start; bn > end; bn-- {
-			block, err := rpcClient.GetBlockByNumber(opts.Globals.Chain, bn, nil)
+			block, err := rpcClient.GetBlockByNumber(opts.Globals.Chain, bn, cacheNew.NoCache)
 			if err != nil {
 				errorChan <- err
 				if errors.Is(err, ethereum.NotFound) {

--- a/src/apps/chifra/internal/blocks/handle_show.go
+++ b/src/apps/chifra/internal/blocks/handle_show.go
@@ -16,7 +16,7 @@ import (
 
 func (opts *BlocksOptions) HandleShowBlocks() error {
 	readOnly := !opts.Cache
-	cache := opts.Globals.CacheStore(readOnly)
+	store := opts.Globals.CacheStore(readOnly)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	fetchData := func(modelChan chan types.Modeler[types.RawBlock], errorChan chan error) {
@@ -37,11 +37,11 @@ func (opts *BlocksOptions) HandleShowBlocks() error {
 				var err error
 				if !opts.Hashes {
 					var b types.SimpleBlock[types.SimpleTransaction]
-					b, err = rpcClient.GetBlockByNumberWithTxs(opts.Globals.Chain, bn, cache)
+					b, err = rpcClient.GetBlockByNumberWithTxs(opts.Globals.Chain, bn, store)
 					block = &b
 				} else {
 					var b types.SimpleBlock[string]
-					b, err = rpcClient.GetBlockByNumber(opts.Globals.Chain, bn, cache)
+					b, err = rpcClient.GetBlockByNumber(opts.Globals.Chain, bn, store)
 					block = &b
 				}
 

--- a/src/apps/chifra/internal/blocks/handle_uncles.go
+++ b/src/apps/chifra/internal/blocks/handle_uncles.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/cacheNew"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/output"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/rpcClient"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/types"
@@ -34,11 +35,11 @@ func (opts *BlocksOptions) HandleUncles() error {
 				var err error
 				if !opts.Hashes {
 					var b types.SimpleBlock[types.SimpleTransaction]
-					b, err = rpcClient.GetBlockByNumberWithTxs(opts.Globals.Chain, bn, nil)
+					b, err = rpcClient.GetBlockByNumberWithTxs(opts.Globals.Chain, bn, cacheNew.NoCache)
 					block = &b
 				} else {
 					var b types.SimpleBlock[string]
-					b, err = rpcClient.GetBlockByNumber(opts.Globals.Chain, bn, nil)
+					b, err = rpcClient.GetBlockByNumber(opts.Globals.Chain, bn, cacheNew.NoCache)
 					block = &b
 				}
 

--- a/src/apps/chifra/internal/blocks/handle_uniq.go
+++ b/src/apps/chifra/internal/blocks/handle_uniq.go
@@ -76,7 +76,7 @@ func (opts *BlocksOptions) ProcessBlockUniqs(chain string, procFunc index.UniqPr
 		}
 
 	} else {
-		if block, err := rpcClient.GetBlockByNumberWithTxs(chain, bn, nil); err != nil {
+		if block, err := rpcClient.GetBlockByNumberWithTxs(chain, bn, cacheNew.NoCache); err != nil {
 			return err
 		} else {
 			miner := block.Miner.Hex()

--- a/src/apps/chifra/internal/logs/handle_show.go
+++ b/src/apps/chifra/internal/logs/handle_show.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/articulate"
+	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/cacheNew"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/identifiers"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/logger"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/output"
@@ -18,6 +19,7 @@ func (opts *LogsOptions) HandleShowLogs() error {
 	chain := opts.Globals.Chain
 	testMode := opts.Globals.TestMode
 	nErrors := 0
+	var store *cacheNew.Store = cacheNew.NoCache
 
 	ctx, cancel := context.WithCancel(context.Background())
 	fetchData := func(modelChan chan types.Modeler[types.RawLog], errorChan chan error) {
@@ -32,7 +34,7 @@ func (opts *LogsOptions) HandleShowLogs() error {
 			defer iterCancel()
 
 			iterFunc := func(app identifiers.ResolvedId, value *types.SimpleReceipt) error {
-				if tx, err := app.FetchTransactionById(chain, false /* needsTraces */, nil); err != nil {
+				if tx, err := app.FetchTransactionById(chain, false /* needsTraces */, store); err != nil {
 					return fmt.Errorf("transaction at %s returned an error: %w", app.String(), err)
 				} else if tx == nil || tx.Receipt == nil {
 					return fmt.Errorf("transaction at %s has no logs", app.String())

--- a/src/apps/chifra/internal/receipts/handle_show.go
+++ b/src/apps/chifra/internal/receipts/handle_show.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/articulate"
+	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/cacheNew"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/identifiers"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/logger"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/output"
@@ -18,7 +19,7 @@ func (opts *ReceiptsOptions) HandleShowReceipts() error {
 	chain := opts.Globals.Chain
 	testMode := opts.Globals.TestMode
 	nErrors := 0
-	// cache := opts.Globals.CacheStore(opts.Cache)
+	var store *cacheNew.Store = cacheNew.NoCache
 
 	ctx, cancel := context.WithCancel(context.Background())
 	fetchData := func(modelChan chan types.Modeler[types.RawReceipt], errorChan chan error) {
@@ -33,7 +34,7 @@ func (opts *ReceiptsOptions) HandleShowReceipts() error {
 			defer iterCancel()
 
 			iterFunc := func(app identifiers.ResolvedId, value *types.SimpleReceipt) error {
-				if tx, err := app.FetchTransactionById(chain, false /* needsTraces */, nil); err != nil {
+				if tx, err := app.FetchTransactionById(chain, false /* needsTraces */, store); err != nil {
 					return fmt.Errorf("transaction at %s returned an error: %w", app.String(), err)
 				} else if tx == nil || tx.Receipt == nil {
 					return fmt.Errorf("transaction at %s has no logs", app.String())

--- a/src/apps/chifra/internal/traces/handle_show.go
+++ b/src/apps/chifra/internal/traces/handle_show.go
@@ -19,7 +19,7 @@ import (
 
 func (opts *TracesOptions) HandleShowTraces() error {
 	abiCache := articulate.NewAbiCache()
-	var store *cacheNew.Store = nil
+	var store *cacheNew.Store = cacheNew.NoCache
 	chain := opts.Globals.Chain
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/src/apps/chifra/internal/transactions/handle_decache.go
+++ b/src/apps/chifra/internal/transactions/handle_decache.go
@@ -63,6 +63,7 @@ func (opts *TransactionsOptions) HandleDecache() error {
 
 	return nil
 
+	// TODO: Review then remove
 	// pairs := []base.NumPair[uint32]{}
 	// for _, rng := range opts.TransactionIds {
 	// 	txIds, err := rng.ResolveTxs(opts.Globals.Chain)

--- a/src/apps/chifra/internal/transactions/handle_uniq.go
+++ b/src/apps/chifra/internal/transactions/handle_uniq.go
@@ -14,7 +14,7 @@ import (
 
 func (opts *TransactionsOptions) HandleUniq() (err error) {
 	readOnly := !opts.Cache
-	cache := opts.Globals.CacheStore(readOnly)
+	store := opts.Globals.CacheStore(readOnly)
 	chain := opts.Globals.Chain
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -36,10 +36,10 @@ func (opts *TransactionsOptions) HandleUniq() (err error) {
 				ts := rpc.GetBlockTimestamp(chain, bn)
 				addrMap := make(index.AddressBooleanMap)
 
-				if trans, err := rpcClient.GetTransactionByAppearance(chain, &app, true, cache); err != nil {
+				if trans, err := rpcClient.GetTransactionByAppearance(chain, &app, true, store); err != nil {
 					errorChan <- err
 				} else {
-					if err = index.UniqFromTransDetails(chain, procFunc, opts.Flow, trans, ts, addrMap, cache); err != nil {
+					if err = index.UniqFromTransDetails(chain, procFunc, opts.Flow, trans, ts, addrMap, store); err != nil {
 						errorChan <- err
 					}
 				}

--- a/src/apps/chifra/pkg/index/uniq_appearances.go
+++ b/src/apps/chifra/pkg/index/uniq_appearances.go
@@ -42,7 +42,7 @@ func UniqFromLogs(chain string, logs []types.SimpleLog, addrMap AddressBooleanMa
 
 // UniqFromTraces extracts addresses from traces
 func UniqFromTraces(chain string, traces []types.SimpleTrace, addrMap AddressBooleanMap) (err error) {
-	var store *cacheNew.Store = nil
+	var store *cacheNew.Store = cacheNew.NoCache
 
 	for _, trace := range traces {
 		trace := trace

--- a/src/apps/chifra/pkg/rpcClient/get_log.go
+++ b/src/apps/chifra/pkg/rpcClient/get_log.go
@@ -87,7 +87,7 @@ func GetLogCountByBlockNumber(chain string, bn uint64) (uint64, error) {
 }
 
 func GetLogsByTransactionId(chain string, bn, txid uint64) ([]types.SimpleLog, error) {
-	var store *cacheNew.Store = nil
+	var store *cacheNew.Store = cacheNew.NoCache
 	blockTs := rpc.GetBlockTimestamp(chain, bn)
 	receipt, err := GetTransactionReceipt(chain, ReceiptQuery{
 		Bn:      bn,

--- a/src/apps/chifra/pkg/rpcClient/get_traces.go
+++ b/src/apps/chifra/pkg/rpcClient/get_traces.go
@@ -94,7 +94,7 @@ func GetTracesByBlockNumber(chain string, bn uint64) ([]types.SimpleTrace, error
 
 // GetTracesCountByTransactionId returns the number of traces in a given transaction
 func GetTracesCountByTransactionId(chain string, bn, txid uint64) (uint64, error) {
-	traces, err := GetTracesByTransactionId(chain, bn, txid, nil)
+	traces, err := GetTracesByTransactionId(chain, bn, txid, cacheNew.NoCache)
 	if err != nil {
 		return 0, err
 	}
@@ -125,7 +125,7 @@ func GetTracesByTransactionId(chain string, bn, txid uint64, store *cacheNew.Sto
 
 // GetTracesCountByTransactionHash returns the number of traces in a given transaction
 func GetTracesCountByTransactionHash(chain string, txHash string) (uint64, error) {
-	traces, err := GetTracesByTransactionHash(chain, txHash, nil, nil)
+	traces, err := GetTracesByTransactionHash(chain, txHash, nil, cacheNew.NoCache)
 	if err != nil {
 		return 0, err
 	}

--- a/src/apps/chifra/pkg/rpcClient/get_transaction.go
+++ b/src/apps/chifra/pkg/rpcClient/get_transaction.go
@@ -69,7 +69,7 @@ func GetPrefundTxByApp(chain string, appearance *types.RawAppearance) (tx *types
 	} else {
 		var blockHash base.Hash
 		var ts int64
-		if block, err := GetBlockByNumber(chain, uint64(0), nil); err != nil {
+		if block, err := GetBlockByNumber(chain, uint64(0), cacheNew.NoCache); err != nil {
 			return nil, err
 		} else {
 			blockHash = block.Hash
@@ -142,7 +142,7 @@ func getBlockReward(bn uint64) *big.Int {
 }
 
 func GetRewardTxByTypeAndApp(chain string, rt RewardType, appearance *types.RawAppearance) (*types.SimpleTransaction, error) {
-	if block, err := GetBlockByNumberWithTxs(chain, uint64(appearance.BlockNumber), nil); err != nil {
+	if block, err := GetBlockByNumberWithTxs(chain, uint64(appearance.BlockNumber), cacheNew.NoCache); err != nil {
 		return nil, err
 	} else {
 		if uncles, err := GetUnclesByNumber(chain, uint64(appearance.BlockNumber)); err != nil {

--- a/src/examples/allContracts/allContracts.go
+++ b/src/examples/allContracts/allContracts.go
@@ -26,14 +26,13 @@ func visitTrace(trace *types.SimpleTrace, data *any) error {
 }
 
 func forEveryTrace(from, to base.Blknum, visitor func(*types.SimpleTrace, *any) error) error {
-	var cache *cacheNew.Store
 	for blknum := from; blknum <= to; blknum++ {
-		if block, err := rpcClient.GetBlockByNumber("mainnet", blknum, cache); err != nil {
+		if block, err := rpcClient.GetBlockByNumber("mainnet", blknum, cacheNew.NoCache); err != nil {
 			return err
 		} else {
 			bar.Tick()
 			for _, txHash := range block.Transactions {
-				if traces, err := rpcClient.GetTracesByTransactionHash("mainnet", txHash, nil, cache); err != nil {
+				if traces, err := rpcClient.GetTracesByTransactionHash("mainnet", txHash, nil, cacheNew.NoCache); err != nil {
 					return err
 				} else {
 					for _, trace := range traces {

--- a/src/examples/findFirst/findFirst.go
+++ b/src/examples/findFirst/findFirst.go
@@ -31,11 +31,10 @@ func main() {
 var chain = "mainnet"
 
 func slowWay() {
-	var cache *cacheNew.Store
 	start := time.Now()
 	bar := logger.NewBarWithStart("Getting stuff", true, 40000, 60000)
 	for i := 40000; i < 60000; i++ {
-		if block, err := rpcClient.GetBlockByNumber(chain, base.Blknum(i), cache); err != nil {
+		if block, err := rpcClient.GetBlockByNumber(chain, base.Blknum(i), cacheNew.NoCache); err != nil {
 			fmt.Println(err)
 		} else {
 			if len(block.Transactions) > 0 {
@@ -52,7 +51,6 @@ func slowWay() {
 }
 
 func fastWay() {
-	var cache *cacheNew.Store
 	bar := logger.NewBarWithStart("Getting stuff", true, 40000, 60000)
 
 	var TxIds []identifiers.Identifier
@@ -69,7 +67,7 @@ func fastWay() {
 		var firstBlock types.SimpleBlock[string]
 		firstBlock.BlockNumber = utils.NOPOS
 		iterateFunc := func(key identifiers.ResolvedId, value *bool) error {
-			if theBlock, err := rpcClient.GetBlockByNumber(chain, base.Blknum(key.BlockNumber), cache); err != nil {
+			if theBlock, err := rpcClient.GetBlockByNumber(chain, base.Blknum(key.BlockNumber), cacheNew.NoCache); err != nil {
 				return err
 			} else {
 				if len(theBlock.Transactions) > 0 {

--- a/src/examples/simple/simple.go
+++ b/src/examples/simple/simple.go
@@ -10,8 +10,7 @@ import (
 )
 
 func main() {
-	var cache *cacheNew.Store
-	if block, err := rpcClient.GetBlockByNumber("mainnet", base.Blknum(3500000), cache); err != nil {
+	if block, err := rpcClient.GetBlockByNumber("mainnet", base.Blknum(3500000), cacheNew.NoCache); err != nil {
 		fmt.Println(err)
 	} else {
 		bytes, _ := json.MarshalIndent(block, "", "  ")


### PR DESCRIPTION
Uses `cacheNew.NoCache` instead of `nil` throughout to make use of the cache (or non-use) easier to find.