### PR TITLE
No cache when close to head

### DIFF
--- a/src/apps/chifra/internal/blocks/handle_count.go
+++ b/src/apps/chifra/internal/blocks/handle_count.go
@@ -92,7 +92,7 @@ func (opts *BlocksOptions) HandleCounts() error {
 					}
 
 					addrMap := make(index.AddressBooleanMap)
-					ts := rpc.GetBlockTimestamp(chain, bn)
+					ts := rpc.GetBlockTimestamp(chain, &bn)
 					if err := opts.ProcessBlockUniqs(chain, countFunc, bn, addrMap, ts, store); err != nil {
 						errorChan <- err
 						if errors.Is(err, ethereum.NotFound) {

--- a/src/apps/chifra/internal/blocks/handle_uniq.go
+++ b/src/apps/chifra/internal/blocks/handle_uniq.go
@@ -45,7 +45,7 @@ func (opts *BlocksOptions) HandleUniq() (err error) {
 					logger.Info("Processing block", fmt.Sprintf("%d", bn))
 				}
 				addrMap := make(index.AddressBooleanMap)
-				ts := rpc.GetBlockTimestamp(chain, bn)
+				ts := rpc.GetBlockTimestamp(chain, &bn)
 				if err := opts.ProcessBlockUniqs(chain, procFunc, bn, addrMap, ts, store); err != nil {
 					errorChan <- err
 					if errors.Is(err, ethereum.NotFound) {

--- a/src/apps/chifra/internal/scrape/handle_blaze_blaze.go
+++ b/src/apps/chifra/internal/scrape/handle_blaze_blaze.go
@@ -138,7 +138,7 @@ func (opts *BlazeOptions) BlazeProcessBlocks(meta *rpcClient.MetaData, blockChan
 
 		ts := tslib.TimestampRecord{
 			Bn: uint32(bn),
-			Ts: uint32(rpc.GetBlockTimestamp(opts.Chain, uint64(bn))),
+			Ts: uint32(rpc.GetBlockTimestamp(opts.Chain, utils.PointerOf(uint64(bn)))),
 		}
 
 		tsChannel <- ts

--- a/src/apps/chifra/internal/scrape/handle_prepare.go
+++ b/src/apps/chifra/internal/scrape/handle_prepare.go
@@ -16,6 +16,7 @@ import (
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/rpc"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/rpcClient"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/tslib"
+	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/utils"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
@@ -50,7 +51,7 @@ func (opts *ScrapeOptions) HandlePrepare(progressThen *rpcClient.MetaData, blaze
 	array := []tslib.TimestampRecord{}
 	array = append(array, tslib.TimestampRecord{
 		Bn: uint32(0),
-		Ts: uint32(rpc.GetBlockTimestamp(opts.Globals.Chain, 0)),
+		Ts: uint32(rpc.GetBlockTimestamp(opts.Globals.Chain, utils.PointerOf(uint64(0)))),
 	})
 	tslib.Append(opts.Globals.Chain, array)
 

--- a/src/apps/chifra/internal/scrape/handle_scrape_blaze.go
+++ b/src/apps/chifra/internal/scrape/handle_scrape_blaze.go
@@ -75,14 +75,14 @@ func WriteTimestamps(chain string, tsArray []tslib.TimestampRecord, endPoint uin
 		if cnt >= len(tsArray) {
 			ts = tslib.TimestampRecord{
 				Bn: uint32(bn),
-				Ts: uint32(rpc.GetBlockTimestamp(chain, bn)),
+				Ts: uint32(rpc.GetBlockTimestamp(chain, &bn)),
 			}
 		} else {
 			ts = tsArray[cnt]
 			if tsArray[cnt].Bn != uint32(bn) {
 				ts = tslib.TimestampRecord{
 					Bn: uint32(bn),
-					Ts: uint32(rpc.GetBlockTimestamp(chain, bn)),
+					Ts: uint32(rpc.GetBlockTimestamp(chain, &bn)),
 				}
 				cnt-- // set it back
 			}

--- a/src/apps/chifra/internal/traces/handle_filter.go
+++ b/src/apps/chifra/internal/traces/handle_filter.go
@@ -8,6 +8,7 @@ import (
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/rpc"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/rpcClient"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/types"
+	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/utils"
 )
 
 func (opts *TracesOptions) HandleFilter() error {
@@ -27,7 +28,7 @@ func (opts *TracesOptions) HandleFilter() error {
 		}
 
 		for index := range traces {
-			traces[index].Timestamp = rpc.GetBlockTimestamp(opts.Globals.Chain, uint64(traces[index].BlockNumber))
+			traces[index].Timestamp = rpc.GetBlockTimestamp(opts.Globals.Chain, utils.PointerOf(uint64(traces[index].BlockNumber)))
 			if opts.Articulate {
 				if err = abiCache.ArticulateTrace(chain, &traces[index]); err != nil {
 					errorChan <- err // continue even with an error

--- a/src/apps/chifra/internal/traces/handle_show.go
+++ b/src/apps/chifra/internal/traces/handle_show.go
@@ -14,6 +14,7 @@ import (
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/rpc"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/rpcClient"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/types"
+	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/utils"
 	"github.com/ethereum/go-ethereum"
 )
 
@@ -37,7 +38,7 @@ func (opts *TracesOptions) HandleShowTraces() error {
 
 			// Timestamp is not part of the raw trace data so we need to get it separately
 			// TxIds don't span blocks, so we can use the first one outside the loop to find timestamp
-			ts := rpc.GetBlockTimestamp(opts.Globals.Chain, uint64(txIds[0].BlockNumber))
+			ts := rpc.GetBlockTimestamp(opts.Globals.Chain, utils.PointerOf(uint64(txIds[0].BlockNumber)))
 			for _, id := range txIds {
 				// Decide on the concrete type of block.Transactions and set values
 				traces, err := rpcClient.GetTracesByTransactionId(opts.Globals.Chain, uint64(id.BlockNumber), uint64(id.TransactionIndex), store)

--- a/src/apps/chifra/internal/transactions/handle_uniq.go
+++ b/src/apps/chifra/internal/transactions/handle_uniq.go
@@ -33,7 +33,7 @@ func (opts *TransactionsOptions) HandleUniq() (err error) {
 
 			for _, app := range txIds {
 				bn := uint64(app.BlockNumber)
-				ts := rpc.GetBlockTimestamp(chain, bn)
+				ts := rpc.GetBlockTimestamp(chain, &bn)
 				addrMap := make(index.AddressBooleanMap)
 
 				if trans, err := rpcClient.GetTransactionByAppearance(chain, &app, true, store); err != nil {

--- a/src/apps/chifra/pkg/cacheNew/item.go
+++ b/src/apps/chifra/pkg/cacheNew/item.go
@@ -8,9 +8,11 @@ import (
 )
 
 // Total header size in bytes
-const HeaderByteSize = 8
+const HeaderByteSize = 4 + 8
+const Magic uint32 = 3735928559 // 0xdeadbeef
 
 type header struct {
+	Magic   uint32
 	Version uint64
 }
 
@@ -25,6 +27,7 @@ func init() {
 		panic(err)
 	}
 	currentHeader = &header{
+		Magic:   Magic,
 		Version: ver.Uint64(),
 	}
 }

--- a/src/apps/chifra/pkg/cacheNew/store_test.go
+++ b/src/apps/chifra/pkg/cacheNew/store_test.go
@@ -67,3 +67,23 @@ func TestStoreWrite(t *testing.T) {
 		t.Fatal("wrong value:", result.Value)
 	}
 }
+
+func TestStoreWriteCancelPending(t *testing.T) {
+	value := &testStoreData{
+		Id:    "1",
+		Value: "trueblocks",
+	}
+	opts := &StoreOptions{
+		Location: MemoryCache,
+	}
+	cacheStore, err := NewStore(opts)
+	if err != nil {
+		panic(err)
+	}
+
+	// Write
+	err = cacheStore.Write(value, &WriteOptions{Pending: true})
+	if err != ErrCanceled {
+		t.Fatal("expected ErrCanceled, but got", err)
+	}
+}

--- a/src/apps/chifra/pkg/identifiers/resolve.go
+++ b/src/apps/chifra/pkg/identifiers/resolve.go
@@ -109,7 +109,7 @@ func snapBnToPeriod(bn uint64, chain, period string) (uint64, error) {
 		dt = dt.FloorYear()
 	}
 
-	firstDate := gostradamus.FromUnixTimestamp(rpc.GetBlockTimestamp(chain, 0))
+	firstDate := gostradamus.FromUnixTimestamp(rpc.GetBlockTimestamp(chain, utils.PointerOf(uint64(0))))
 	if dt.Time().Before(firstDate.Time()) {
 		dt = firstDate
 	}
@@ -189,7 +189,7 @@ func (p *Point) resolvePoint(chain string) uint64 {
 		if err == tslib.ErrInTheFuture {
 			provider := config.GetRpcProvider(chain)
 			latest := rpcClient.BlockNumber(provider)
-			tsFuture := rpc.GetBlockTimestamp(chain, latest)
+			tsFuture := rpc.GetBlockTimestamp(chain, &latest)
 			secs := uint64(tsFuture - base.Timestamp(p.Number))
 			blks := (secs / 13)
 			bn = latest + blks

--- a/src/apps/chifra/pkg/rpc/query.go
+++ b/src/apps/chifra/pkg/rpc/query.go
@@ -9,6 +9,7 @@ import (
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/base"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/config"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/logger"
+	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/utils"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 )
@@ -85,12 +86,17 @@ func GetTxFromNumberAndId(chain string, blkNum, txId uint64) (ethTypes.Transacti
 }
 
 // GetBlockTimestamp returns the timestamp associated with a given block
-func GetBlockTimestamp(chain string, bn uint64) base.Timestamp {
+func GetBlockTimestamp(chain string, bn *uint64) base.Timestamp {
 	provider := config.GetRpcProvider(chain)
 	ec := getClient(provider)
 	defer ec.Close()
 
-	r, err := ec.HeaderByNumber(context.Background(), big.NewInt(int64(bn)))
+	var blockNumber *big.Int
+	if bn != nil {
+		blockNumber = big.NewInt(int64(*bn))
+	}
+
+	r, err := ec.HeaderByNumber(context.Background(), blockNumber)
 	if err != nil {
 		logger.Error("Could not connect to RPC client", err)
 		return 0
@@ -100,7 +106,7 @@ func GetBlockTimestamp(chain string, bn uint64) base.Timestamp {
 	if ts == 0 {
 		// The RPC does not return a timestamp for block zero, so we simulate it with ts from block one less 13 seconds
 		// TODO: Chain specific
-		return GetBlockTimestamp(chain, 1) - 13
+		return GetBlockTimestamp(chain, utils.PointerOf(uint64(1))) - 13
 	}
 
 	return ts

--- a/src/apps/chifra/pkg/rpcClient/client_integration_test.go
+++ b/src/apps/chifra/pkg/rpcClient/client_integration_test.go
@@ -47,7 +47,7 @@ func Test_Client(t *testing.T) {
 		t.Error("provider chain id is 1")
 	}
 
-	ts := rpc.GetBlockTimestamp(chain, 1)
+	ts := rpc.GetBlockTimestamp(chain, utils.PointerOf(uint64(1)))
 	blockOneTimestamp := int64(1438269988)
 	if ts != blockOneTimestamp {
 		t.Error("timestamp for block 1 is not correct")

--- a/src/apps/chifra/pkg/rpcClient/get_log.go
+++ b/src/apps/chifra/pkg/rpcClient/get_log.go
@@ -41,7 +41,7 @@ func getSimpleLogs(chain string, filter types.SimpleLogFilter) ([]types.SimpleLo
 		for _, rawLog := range rawLogs {
 			bn := mustParseUint(rawLog.BlockNumber)
 			if bn != curBlock {
-				curTs = rpc.GetBlockTimestamp(chain, bn)
+				curTs = rpc.GetBlockTimestamp(chain, &bn)
 				curDate = gostradamus.FromUnixTimestamp(curTs)
 				curBlock = bn
 			}
@@ -88,7 +88,7 @@ func GetLogCountByBlockNumber(chain string, bn uint64) (uint64, error) {
 
 func GetLogsByTransactionId(chain string, bn, txid uint64) ([]types.SimpleLog, error) {
 	var store *cacheNew.Store = cacheNew.NoCache
-	blockTs := rpc.GetBlockTimestamp(chain, bn)
+	blockTs := rpc.GetBlockTimestamp(chain, &bn)
 	receipt, err := GetTransactionReceipt(chain, ReceiptQuery{
 		Bn:      bn,
 		Txid:    txid,

--- a/src/apps/chifra/pkg/rpcClient/get_receipt.go
+++ b/src/apps/chifra/pkg/rpcClient/get_receipt.go
@@ -48,7 +48,7 @@ func GetTransactionReceipt(chain string, query ReceiptQuery, store *cacheNew.Sto
 	}
 
 	if query.NeedsTs && query.Ts == 0 {
-		query.Ts = rpc.GetBlockTimestamp(chain, query.Bn)
+		query.Ts = rpc.GetBlockTimestamp(chain, &query.Bn)
 	}
 
 	logs := []types.SimpleLog{}

--- a/src/apps/chifra/pkg/tslib/todate.go
+++ b/src/apps/chifra/pkg/tslib/todate.go
@@ -27,7 +27,7 @@ func FromNameToDate(chain, name string) (gostradamus.DateTime, error) {
 
 	if name == "latest" {
 		meta, _ := rpcClient.GetMetaData(chain, false)
-		ts := rpc.GetBlockTimestamp(chain, meta.Latest)
+		ts := rpc.GetBlockTimestamp(chain, utils.PointerOf(meta.Latest))
 		return FromTsToDate(ts)
 	}
 

--- a/src/apps/chifra/pkg/types/types_block.go
+++ b/src/apps/chifra/pkg/types/types_block.go
@@ -13,10 +13,13 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"time"
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/base"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/cacheNew"
 )
+
+var PendingPeriod = (5 * time.Minute).Milliseconds()
 
 type BlockTransaction interface {
 	string | SimpleTransaction
@@ -333,6 +336,10 @@ func (s *SimpleBlock[string]) Dup(target *SimpleBlock[SimpleTransaction]) {
 	target.Timestamp = s.Timestamp
 	target.Uncles = s.Uncles
 	target.raw = s.raw
+}
+
+func (s *SimpleBlock[Tx]) Pending(latestTimestamp int64) bool {
+	return (latestTimestamp - s.Timestamp) <= PendingPeriod
 }
 
 // EXISTING_CODE

--- a/test/gold/tools/getBlocks/getBlocks_decache.txt
+++ b/test/gold/tools/getBlocks/getBlocks_decache.txt
@@ -2,9 +2,9 @@ chifra blocks  1152642 --decache
 TEST[DATE|TIME] Blocks:  [1152642]
 TEST[DATE|TIME] Decache:  true
 TEST[DATE|TIME] Format:  json
-INFO[DATE|TIME] false Removed  1  items and  305  bytes. 001152642.bin
-INFO[DATE|TIME] false Removed  2  items and  710  bytes. 001152642-00000.bin
-INFO[DATE|TIME] 2 items totaling 710 bytes were removed from the cache.                                                             
+INFO[DATE|TIME] false Removed  1  items and  309  bytes. 001152642.bin
+INFO[DATE|TIME] false Removed  2  items and  718  bytes. 001152642-00000.bin
+INFO[DATE|TIME] 2 items totaling 718 bytes were removed from the cache.                                                             
 {
   "data": []
 }


### PR DESCRIPTION
I use `Pending` instead of `Finalized`, because it fits better with Go's default (zero) values.

In `GetBlockTimestamp` I had to change `blockNumber` type from `uint64` to `*uint64` to be able to get the latest block, it's the only reason why so many files were changed.

Added magic number to cache header.