### PR TITLE
Moved protobufs compilation step to make generate

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,13 +41,6 @@ if(CURL_FOUND)
 endif(CURL_FOUND)
 
 # ----------------------------------------------------------------------------------------
-# Protoc is needed to compile protobuf files
-#
-message(STATUS "======== LOOKING FOR PROTOC ========================")
-find_package(Protobuf 3.21)
-message(STATUS ${Protobuf_PROTOC_EXECUTABLE})
-
-# ----------------------------------------------------------------------------------------
 # Globally available C++ settings
 set(DL_LIB "-ldl")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1z -Werror -Wall -O2 -fPIC")
@@ -88,29 +81,12 @@ function(ADD_GO_INSTALLABLE_PROGRAM NAME MAIN_SRC DEST_DIR)
 endfunction(ADD_GO_INSTALLABLE_PROGRAM)
 
 # ----------------------------------------------------------------------------------------
-function(COMPILE_PROTOBUFFERS NAME MAIN_SRC)
-  message("Compiling protobuf files")
-  get_filename_component(MAIN_SRC_ABS ${MAIN_SRC} ABSOLUTE)
-  add_custom_target(${NAME})
-  add_custom_command(TARGET ${NAME}
-                    COMMAND protoc
-                    --go_out=.
-                    --go_opt=paths=source_relative
-                    --go-grpc_out=.
-                    --go-grpc_opt=paths=source_relative
-                    ${MAIN_SRC}
-                    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/proto
-                    DEPENDS ${MAIN_SRC_ABS} ${MAIN_SRC})
-  add_custom_target(${NAME}_all ALL DEPENDS ${NAME})
-endfunction(COMPILE_PROTOBUFFERS)
-
-# ----------------------------------------------------------------------------------------
 # Enable testing
 # enable_testing()
 add_custom_target(lint COMMAND "golangci-lint" "run" WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/apps/chifra")
 add_custom_target(format COMMAND "${BIN_DIR}/makeClass" "--format" WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
 add_custom_target(options COMMAND "${BIN_DIR}/makeClass" "--options --openapi" WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
-add_custom_target(generate COMMAND "${BIN_DIR}/makeClass" "--all --readmes --openapi --options --gocmds --sdk" WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+add_custom_target(generate COMMAND "${BIN_DIR}/makeClass" "--all --readmes --openapi --options --gocmds --sdk --protobuf" WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
 add_custom_target(sdk COMMAND "${BIN_DIR}/makeClass" "--sdk" WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
 add_custom_target(gocmds COMMAND "${BIN_DIR}/makeClass" "--options --gocmds" WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
 add_custom_target(readmes COMMAND "${BIN_DIR}/makeClass" "--readmes" WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")

--- a/src/apps/chifra/CMakeLists.txt
+++ b/src/apps/chifra/CMakeLists.txt
@@ -3,10 +3,6 @@ cmake_minimum_required (VERSION 3.5)
 # application project
 project (chifra)
 
-if(PROTOBUF_FOUND)
-  COMPILE_PROTOBUFFERS(chifra_proto chifra.proto)
-endif(PROTOBUF_FOUND)
-
 ADD_GO_INSTALLABLE_PROGRAM(chifra *.go ${BIN_DIR})
 
 # Define the executable to be generated

--- a/src/dev_tools/makeClass/handle_protobuf.cpp
+++ b/src/dev_tools/makeClass/handle_protobuf.cpp
@@ -1,0 +1,23 @@
+#include "utillib.h"
+#include "options.h"
+
+bool COptions::handle_protobuf(void) {
+    CToml config(rootConfigToml_makeClass);
+    bool enabled = config.getConfigBool("enabled", "protobuf", false);
+    if (!enabled) {
+        LOG_WARN("Skipping protobuf compilation...");
+        return true;
+    }
+
+    LOG_INFO(cYellow, "handling protobufs...", cOff);
+
+    string_q res = doCommand(
+        "protoc"
+        " --go_out=."
+        " --go_opt=paths=source_relative"
+        " --go-grpc_out=."
+        " --go-grpc_opt=paths=source_relative"
+        " apps/chifra/proto/chifra.proto"
+    );
+    return res.empty();
+}

--- a/src/dev_tools/makeClass/options.cpp
+++ b/src/dev_tools/makeClass/options.cpp
@@ -28,6 +28,7 @@ static const COption params[] = {
     COption("format", "f", "", OPT_SWITCH, "format source code files (.cpp and .h) found in local folder and below"),
     COption("sdk", "s", "", OPT_SWITCH, "create typescript sdk"),
     COption("openapi", "A", "", OPT_SWITCH, "export openapi.yaml file for API documentation"),
+    COption("protobuf", "p", "", OPT_SWITCH, "compile protobufs"),
     COption("", "", "", OPT_DESCRIPTION, "Automatically writes C++ for various purposes."),
     // clang-format on
 };
@@ -75,6 +76,9 @@ bool COptions::parseArguments(string_q& command) {
 
         } else if (arg == "-A" || arg == "--openapi") {
             openapi = true;
+
+        } else if (arg == "-p" || arg == "--protobuf") {
+            protobuf = true;
 
         } else if (startsWith(arg, '-')) {  // do not collapse
 
@@ -199,6 +203,8 @@ bool COptions::parseArguments(string_q& command) {
     if (format && !handle_format())
         return false;
     if (sdk && !handle_sdk())
+        return false;
+    if (protobuf && !handle_protobuf())
         return false;
 
     // Default to run if we get only all

--- a/src/dev_tools/makeClass/options.h
+++ b/src/dev_tools/makeClass/options.h
@@ -40,6 +40,7 @@ class COptions : public COptionsBase {
     bool all;
     bool sdk;
     bool openapi;
+    bool protobuf;
 
     CClassDefinitionArray classDefs;
     CClassDefinitionArray dataModels;
@@ -85,6 +86,8 @@ class COptions : public COptionsBase {
     void verifyGoEnumValidators(void);
 
     bool writeOpenApiFile(void);
+
+    bool handle_protobuf(void);
 
     string_q getReturnTypes(const CCommandOption& ep, CStringArray& returnTypes);
     void verifyDescriptions(void);


### PR DESCRIPTION
Right now protocol buffers are compiled if the compiler is installed. But this is annoying and also caused issue for at least 1 user (https://discord.com/channels/570963863428661248/814482078498029568/1144215163956891771). 

This PR moves protobuf compilation step to `make generate --protobuf` (if it's enabled in `makeClass.toml`)