### PR TITLE
Bugfix/call tests

### DIFF
--- a/src/apps/chifra/pkg/parser/contract_argument.go
+++ b/src/apps/chifra/pkg/parser/contract_argument.go
@@ -19,7 +19,7 @@ type ContractArgument struct {
 	Number  *ArgNumber    `parser:"| @Decimal"`          // the value if it's a number
 	Boolean *ArgBool      `parser:"| @('true'|'false')"` // the value if it's a boolean
 	Hex     *ArgHex       `parser:"| @Hex"`              // the value if it's a hex string
-	EnsAddr *ArgAddress   `parser:"| @EnsDomain"`        // the value if it's an ENS domain
+	EnsAddr *ArgEnsDomain `parser:"| @EnsDomain"`        // the value if it's an ENS domain
 }
 
 // Interface returns the value as interface{} (any)
@@ -114,6 +114,7 @@ func (a *ContractArgument) AbiType(abiType *abi.Type) (any, error) {
 	return a.Interface(), nil
 }
 
+// wrongTypeError returns user-friendly errors
 func wrongTypeError(expectedType string, token lexer.Token, value any) error {
 	t := reflect.TypeOf(value)
 	typeName := t.String()

--- a/src/apps/chifra/pkg/parser/contract_argument.go
+++ b/src/apps/chifra/pkg/parser/contract_argument.go
@@ -29,7 +29,8 @@ func (a *ContractArgument) Interface() any {
 	}
 
 	if a.String != nil {
-		return *a.String
+		value := *a.String
+		return string(value)
 	}
 
 	if a.Number != nil {
@@ -120,9 +121,6 @@ func wrongTypeError(expectedType string, token lexer.Token, value any) error {
 	// kinds between this range are all (u)int, called "integer" in Solidity
 	if kind > 1 && kind < 12 {
 		typeName = "integer"
-	}
-	if expectedType == "hash" || expectedType == "address" {
-		typeName = "parser.ArgString"
 	}
 	return fmt.Errorf("expected %s, but got %s \"%s\"", expectedType, typeName, token)
 }

--- a/src/apps/chifra/pkg/parser/contract_argument_types.go
+++ b/src/apps/chifra/pkg/parser/contract_argument_types.go
@@ -12,23 +12,23 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// ArgAddress is a type alias to capture bool values correctly
-type ArgAddress common.Address
+// ArgEnsDomain is a type alias to capture ENS domains
+type ArgEnsDomain common.Address
 
-func (b *ArgAddress) Capture(values []string) error {
+func (b *ArgEnsDomain) Capture(values []string) error {
 	if strings.Contains(values[0], ".eth") {
-		debug("ArgAddress::Capture:Ens", values)
+		debug("ArgEnsDomain::Capture:Ens", values)
 		conn := rpc.TempConnection("mainnet")
 		addrStr, _ := conn.GetEnsAddress(values[0])
-		*b = ArgAddress(common.HexToAddress(addrStr))
+		*b = ArgEnsDomain(common.HexToAddress(addrStr))
 	} else {
-		debug("ArgAddress::Capture:Hex", values)
-		*b = ArgAddress(common.HexToAddress(values[0]))
+		debug("ArgEnsDomain::Capture:Hex", values)
+		*b = ArgEnsDomain(common.HexToAddress(values[0]))
 	}
 	return nil
 }
 
-// ArgString is a type alias to capture bool values correctly
+// ArgString is a type alias to capture strings correctly
 type ArgString string
 
 func (b *ArgString) Capture(values []string) error {

--- a/src/apps/chifra/pkg/parser/contract_call_test.go
+++ b/src/apps/chifra/pkg/parser/contract_call_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"errors"
 	"math/big"
 	"reflect"
 	"strings"
@@ -8,7 +9,6 @@ import (
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/base"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/utils"
-	"github.com/alecthomas/participle/v2/lexer"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -332,7 +332,7 @@ func TestArgument_AbiType_Errors(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, err = parsed.FunctionNameCall.Arguments[1].AbiType(&testAbi.Methods["address"].Inputs[0].Type)
-	expected := wrongTypeError("address", lexer.Token{Value: `0x6982508145454ce325ddbe47a25d4ec3d23119a1`}, "0x6982508145454ce325ddbe47a25d4ec3d23119a1")
+	expected := errors.New(`expected address, but got string "0x6982508145454ce325ddbe47a25d4ec3d23119a1"`)
 	if err.Error() != expected.Error() {
 		t.Fatal("got wrong error:", err, "expected:", expected)
 	}
@@ -342,7 +342,7 @@ func TestArgument_AbiType_Errors(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, err = parsed.FunctionNameCall.Arguments[0].AbiType(&testAbi.Methods["bool"].Inputs[0].Type)
-	expected = wrongTypeError("bool", lexer.Token{Value: `111`}, 111)
+	expected = errors.New(`expected bool, but got integer "111"`)
 	if err.Error() != expected.Error() {
 		t.Fatal("got wrong error:", err, "expected:", expected)
 	}
@@ -352,7 +352,7 @@ func TestArgument_AbiType_Errors(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, err = parsed.FunctionNameCall.Arguments[0].AbiType(&testAbi.Methods["bytes32"].Inputs[0].Type)
-	expected = wrongTypeError("hash", lexer.Token{Value: `hello`}, "hello")
+	expected = errors.New(`expected hash, but got string "hello"`)
 	if err.Error() != expected.Error() {
 		t.Fatal("got wrong error:", err, "expected:", expected)
 	}

--- a/src/apps/chifra/pkg/parser/lexer_parser.go
+++ b/src/apps/chifra/pkg/parser/lexer_parser.go
@@ -15,7 +15,7 @@ import (
 // https://docs.soliditylang.org/en/v0.8.17/grammar.html#a4.SolidityLexer.Identifier
 var ourLexer = lexer.MustSimple([]lexer.SimpleRule{
 	// matched lexer tokens (order matters)
-	{Name: `EnsDomain`, Pattern: `[a-zA-Z0-9]+\.eth`}, // TODO: this token does not handle subdomains or dashes
+	{Name: `EnsDomain`, Pattern: `([a-zA-Z0-9]+)(\.[a-zA-Z0-9]+)*\.eth`}, // TODO: this token does not handle dashes
 	{Name: `Hex`, Pattern: `0x[[:xdigit:]]+`},
 	{Name: `String`, Pattern: `"(?:\\.|[^"])*"`},
 	{Name: `Decimal`, Pattern: `[-+]?\d+`},


### PR DESCRIPTION
1. Fixed errors. Previous version was returning `expected address, but got _parser.ArgString_: "abc"` and the user doesn't know what `parser.ArgString` is. Now it returns: `expected address, but got string: "abc"`
1. Subdomain support 
1. Renamed ArgAddress to ArgEnsDomain as it's only dealing with the domains