### PR TITLE
Added ChunkWritten notification type

### DIFF
--- a/src/apps/chifra/internal/scrape/notify.go
+++ b/src/apps/chifra/internal/scrape/notify.go
@@ -15,9 +15,15 @@ import (
 
 var ErrConfiguredButNotRunning = fmt.Errorf("listener is configured but not running")
 
+// NotifyConfigured returns true if notification feature is configured
+func NotifyConfigured() (bool, string) {
+	endpoint := config.GetSettings().Notify.Url
+	return endpoint != "", endpoint
+}
+
 // Notify may be used to tell other processes about progress.
 func Notify[T notify.NotificationPayload](notification notify.Notification[T]) error {
-	endpoint := config.GetSettings().NotifyUrl
+	_, endpoint := NotifyConfigured()
 	if endpoint == "" {
 		return nil
 	}

--- a/src/apps/chifra/internal/scrape/scrape_consolidate.go
+++ b/src/apps/chifra/internal/scrape/scrape_consolidate.go
@@ -118,10 +118,22 @@ func (bm *BlazeManager) Consolidate(blocks []base.Blknum) (error, bool) {
 				report.FileSize = file.FileSize(chunkPath)
 				report.Report()
 			}
-			if err := Notify(notify.Notification[string]{
-				Msg:     notify.MessageChunkWritten,
-				Meta:    bm.meta,
-				Payload: chunkRange.String(),
+			var cidString string
+			if ok, _ := NotifyConfigured(); ok {
+				if cid, err := index.ChunkCid(chunkPath); err != nil {
+					return err, true
+				} else {
+					cidString = cid.String()
+				}
+			}
+			if err := Notify(notify.Notification[notify.NotificationPayloadChunkWritten]{
+				Msg:  notify.MessageChunkWritten,
+				Meta: bm.meta,
+				Payload: notify.NotificationPayloadChunkWritten{
+					Cid:    cidString,
+					Range:  chunkRange.String(),
+					Author: config.GetRootConfig().Settings.Notify.Author,
+				},
 			}); err != nil {
 				return err, true
 			}

--- a/src/apps/chifra/pkg/config/settingsGroup.go
+++ b/src/apps/chifra/pkg/config/settingsGroup.go
@@ -5,11 +5,16 @@
 package config
 
 type settingsGroup struct {
-	CachePath      string `toml:"cachePath"`
-	IndexPath      string `toml:"indexPath"`
-	DefaultChain   string `toml:"defaultChain"`
-	DefaultGateway string `toml:"defaultGateway,omitempty"`
-	NotifyUrl      string `toml:"notifyUrl" json:"notifyUrl,omitempty"`
+	CachePath      string      `toml:"cachePath"`
+	IndexPath      string      `toml:"indexPath"`
+	DefaultChain   string      `toml:"defaultChain"`
+	DefaultGateway string      `toml:"defaultGateway,omitempty"`
+	Notify         notifyGroup `toml:"notify"`
+}
+
+type notifyGroup struct {
+	Url    string `toml:"url" json:"url,omitempty"`
+	Author string `toml:"author" json:"author,omitempty"`
 }
 
 func GetSettings() settingsGroup {

--- a/src/apps/chifra/pkg/index/chunk.go
+++ b/src/apps/chifra/pkg/index/chunk.go
@@ -14,8 +14,12 @@
 package index
 
 import (
+	"io"
+	"os"
+
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/base"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/config"
+	"github.com/ipfs/go-cid"
 )
 
 // The Chunk data structure consists of three parts. A FileRange, a Index structure, and a Bloom that
@@ -69,4 +73,24 @@ func (chunk *Chunk) Close() {
 		chunk.Index.File.Close()
 		chunk.Index.File = nil
 	}
+}
+
+var cidBuilder cid.V0Builder
+
+// ChunkCid returns IPFS CID for the chunk without uploading it
+func ChunkCid(path string) (chunkCid cid.Cid, err error) {
+	file, err := os.OpenFile(path, os.O_RDONLY, 0)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+	return calculateCid(file)
+}
+
+func calculateCid(r io.Reader) (chunkCid cid.Cid, err error) {
+	bytes, err := io.ReadAll(r)
+	if err != nil {
+		return
+	}
+	return cidBuilder.Sum(bytes)
 }

--- a/src/apps/chifra/pkg/index/chunk_test.go
+++ b/src/apps/chifra/pkg/index/chunk_test.go
@@ -1,0 +1,17 @@
+package index
+
+import (
+	"strings"
+	"testing"
+)
+
+func Test_calculateCid(t *testing.T) {
+	r := strings.NewReader("hello world")
+	cid, err := calculateCid(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s := cid.String(); s != "QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L4" {
+		t.Fatal("wrong CID:", s)
+	}
+}

--- a/src/apps/chifra/pkg/notify/notification.go
+++ b/src/apps/chifra/pkg/notify/notification.go
@@ -12,5 +12,6 @@ type Notification[T NotificationPayload] struct {
 
 type NotificationPayload interface {
 	[]NotificationPayloadAppearance |
+		NotificationPayloadChunkWritten |
 		string
 }

--- a/src/apps/chifra/pkg/notify/scraper.go
+++ b/src/apps/chifra/pkg/notify/scraper.go
@@ -10,7 +10,7 @@ import (
 const (
 	MessageChunkWritten Message = "chunkWritten"
 	MessageStageUpdated Message = "stageUpdated"
-	MessageAppearance   Message = "asppearance"
+	MessageAppearance   Message = "appearance"
 )
 
 type NotificationPayloadAppearance struct {
@@ -18,7 +18,7 @@ type NotificationPayloadAppearance struct {
 	// We use string for block number to ensure it's never
 	// too big
 	BlockNumber      string `json:"blockNumber"`
-	TransactionIndex uint32
+	TransactionIndex uint32 `json:"txid"`
 }
 
 func (n *NotificationPayloadAppearance) FromString(s string) (err error) {
@@ -57,4 +57,10 @@ func NewAppearanceNotification(meta *rpc.MetaData, appearances []NotificationPay
 		Meta:    meta,
 		Payload: appearances,
 	}
+}
+
+type NotificationPayloadChunkWritten struct {
+	Cid    string `json:"cid"`
+	Range  string `json:"range"`
+	Author string `json:"author"`
 }


### PR DESCRIPTION
ChunkWritten notification is passed to the queue and then Key adds chunk's CID, range and reporter (author) to the database. We can then check for duplicates (same range but different CID) to make sure the data is correct.
