### PR TITLE
Fixed 0 being always reported as chunk range

### DIFF
--- a/src/apps/chifra/internal/scrape/scrape_chunk_notify.go
+++ b/src/apps/chifra/internal/scrape/scrape_chunk_notify.go
@@ -1,6 +1,7 @@
 package scrapePkg
 
 import (
+	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/base"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/config"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/index"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/notify"
@@ -13,13 +14,15 @@ func NotifyChunkWritten(chunk index.Chunk, chunkPath string) (err error) {
 			return err
 		}
 	}
+	// Generate range from path, as chunks sometimes don't have Range set
+	chunkRange := base.RangeFromFilename(index.ToIndexPath(chunkPath))
 	return Notify(notify.Notification[[]notify.NotificationPayloadChunkWritten]{
 		Msg:  notify.MessageChunkWritten,
 		Meta: nil,
 		Payload: []notify.NotificationPayloadChunkWritten{
 			{
 				Cid:    cidString,
-				Range:  chunk.Range.String(),
+				Range:  chunkRange.String(),
 				Author: config.GetRootConfig().Settings.Notify.Author,
 			},
 		},


### PR DESCRIPTION
Previously when we were sending `ChunkWritten` notification, all ranges were reported as `0-0`. 
