### PR TITLE
3650 fix import cycles

### DIFF
--- a/src/apps/chifra/internal/blocks/handle_hashes.go
+++ b/src/apps/chifra/internal/blocks/handle_hashes.go
@@ -40,7 +40,7 @@ func (opts *BlocksOptions) HandleHashes() error {
 
 		} else {
 			bar := logger.NewBar(logger.BarOptions{
-				Enabled: !testMode && !utils.IsTerminal(),
+				Enabled: !testMode && !logger.IsTerminal(),
 				Total:   int64(cnt),
 			})
 

--- a/src/apps/chifra/internal/blocks/handle_logs.go
+++ b/src/apps/chifra/internal/blocks/handle_logs.go
@@ -44,7 +44,7 @@ func (opts *BlocksOptions) HandleLogs() error {
 
 		} else {
 			bar := logger.NewBar(logger.BarOptions{
-				Enabled: !testMode && !utils.IsTerminal(),
+				Enabled: !testMode && !logger.IsTerminal(),
 				Total:   int64(cnt),
 			})
 

--- a/src/apps/chifra/internal/blocks/handle_show.go
+++ b/src/apps/chifra/internal/blocks/handle_show.go
@@ -43,7 +43,7 @@ func (opts *BlocksOptions) HandleShow() error {
 
 		} else {
 			bar := logger.NewBar(logger.BarOptions{
-				Enabled: !testMode && !utils.IsTerminal(),
+				Enabled: !testMode && !logger.IsTerminal(),
 				Total:   int64(cnt),
 			})
 

--- a/src/apps/chifra/internal/blocks/handle_uncles.go
+++ b/src/apps/chifra/internal/blocks/handle_uncles.go
@@ -40,7 +40,7 @@ func (opts *BlocksOptions) HandleUncles() error {
 
 		} else {
 			bar := logger.NewBar(logger.BarOptions{
-				Enabled: !testMode && !utils.IsTerminal(),
+				Enabled: !testMode && !logger.IsTerminal(),
 				Total:   int64(cnt),
 			})
 

--- a/src/apps/chifra/internal/blocks/handle_uniq.go
+++ b/src/apps/chifra/internal/blocks/handle_uniq.go
@@ -41,7 +41,7 @@ func (opts *BlocksOptions) HandleUniq() error {
 
 		} else {
 			bar := logger.NewBar(logger.BarOptions{
-				Enabled: !testMode && !utils.IsTerminal(),
+				Enabled: !testMode && !logger.IsTerminal(),
 				Total:   int64(cnt),
 			})
 

--- a/src/apps/chifra/internal/blocks/handle_withdrawals.go
+++ b/src/apps/chifra/internal/blocks/handle_withdrawals.go
@@ -40,7 +40,7 @@ func (opts *BlocksOptions) HandleWithdrawals() error {
 
 		} else {
 			bar := logger.NewBar(logger.BarOptions{
-				Enabled: !testMode && !utils.IsTerminal(),
+				Enabled: !testMode && !logger.IsTerminal(),
 				Total:   int64(cnt),
 			})
 

--- a/src/apps/chifra/internal/chunks/handle_check_deep.go
+++ b/src/apps/chifra/internal/chunks/handle_check_deep.go
@@ -57,7 +57,7 @@ func (opts *ChunksOptions) CheckDeep(cacheMan *manifest.Manifest, report *types.
 		logger.Info("Checking each address in each index against its Bloom filter...")
 		iterFunc = func(rangeStr string, item *reporter) (err error) {
 			rng := base.RangeFromRangeString(item.chunk.Range)
-			_, path := rng.RangeToFilename(chain)
+			path := rng.RangeToFilename(chain)
 			bl, err := index.OpenBloom(index.ToBloomPath(path), true /* check */)
 			if err != nil {
 				return

--- a/src/apps/chifra/internal/chunks/handle_truncate.go
+++ b/src/apps/chifra/internal/chunks/handle_truncate.go
@@ -77,7 +77,7 @@ func (opts *ChunksOptions) HandleTruncate(blockNums []base.Blknum) error {
 				nChunksRemoved++
 			} else {
 				// We did not remove the chunk, so we need to keep track of where the truncated index ends
-				latestChunk = base.Max2(latestChunk, rng.Last)
+				latestChunk = base.Max(latestChunk, rng.Last)
 				bar.Prefix = fmt.Sprintf("Not removing %s", rng)
 			}
 			bar.Tick()

--- a/src/apps/chifra/internal/export/handle_balances.go
+++ b/src/apps/chifra/internal/export/handle_balances.go
@@ -55,7 +55,7 @@ func (opts *ExportOptions) HandleBalances(monitorArray []monitor.Monitor) error 
 				} else {
 					bar := logger.NewBar(logger.BarOptions{
 						Prefix:  mon.Address.Hex(),
-						Enabled: !testMode && !utils.IsTerminal(),
+						Enabled: !testMode && !logger.IsTerminal(),
 						Total:   int64(cnt),
 					})
 

--- a/src/apps/chifra/internal/export/handle_logs.go
+++ b/src/apps/chifra/internal/export/handle_logs.go
@@ -57,7 +57,7 @@ func (opts *ExportOptions) HandleLogs(monitorArray []monitor.Monitor) error {
 				} else {
 					bar := logger.NewBar(logger.BarOptions{
 						Prefix:  mon.Address.Hex(),
-						Enabled: !testMode && !utils.IsTerminal(),
+						Enabled: !testMode && !logger.IsTerminal(),
 						Total:   int64(cnt),
 					})
 

--- a/src/apps/chifra/internal/export/handle_neighbors.go
+++ b/src/apps/chifra/internal/export/handle_neighbors.go
@@ -48,7 +48,7 @@ func (opts *ExportOptions) HandleNeighbors(monitorArray []monitor.Monitor) error
 				} else {
 					bar := logger.NewBar(logger.BarOptions{
 						Prefix:  mon.Address.Hex(),
-						Enabled: !testMode && !utils.IsTerminal(),
+						Enabled: !testMode && !logger.IsTerminal(),
 						Total:   int64(cnt),
 					})
 

--- a/src/apps/chifra/internal/export/handle_receipts.go
+++ b/src/apps/chifra/internal/export/handle_receipts.go
@@ -57,7 +57,7 @@ func (opts *ExportOptions) HandleReceipts(monitorArray []monitor.Monitor) error 
 				} else {
 					bar := logger.NewBar(logger.BarOptions{
 						Prefix:  mon.Address.Hex(),
-						Enabled: !testMode && !utils.IsTerminal(),
+						Enabled: !testMode && !logger.IsTerminal(),
 						Total:   int64(cnt),
 					})
 

--- a/src/apps/chifra/internal/export/handle_show.go
+++ b/src/apps/chifra/internal/export/handle_show.go
@@ -51,7 +51,7 @@ func (opts *ExportOptions) HandleShow(monitorArray []monitor.Monitor) error {
 				} else {
 					bar := logger.NewBar(logger.BarOptions{
 						Prefix:  mon.Address.Hex(),
-						Enabled: !testMode && !utils.IsTerminal(),
+						Enabled: !testMode && !logger.IsTerminal(),
 						Total:   int64(cnt),
 					})
 

--- a/src/apps/chifra/internal/export/handle_statements.go
+++ b/src/apps/chifra/internal/export/handle_statements.go
@@ -50,7 +50,7 @@ func (opts *ExportOptions) HandleStatements(monitorArray []monitor.Monitor) erro
 				} else {
 					bar := logger.NewBar(logger.BarOptions{
 						Prefix:  mon.Address.Hex(),
-						Enabled: !testMode && !utils.IsTerminal(),
+						Enabled: !testMode && !logger.IsTerminal(),
 						Total:   int64(cnt),
 					})
 

--- a/src/apps/chifra/internal/export/handle_traces.go
+++ b/src/apps/chifra/internal/export/handle_traces.go
@@ -51,7 +51,7 @@ func (opts *ExportOptions) HandleTraces(monitorArray []monitor.Monitor) error {
 				} else {
 					bar := logger.NewBar(logger.BarOptions{
 						Prefix:  mon.Address.Hex(),
-						Enabled: !testMode && !utils.IsTerminal(),
+						Enabled: !testMode && !logger.IsTerminal(),
 						Total:   int64(cnt),
 					})
 

--- a/src/apps/chifra/internal/export/handle_withdrawals.go
+++ b/src/apps/chifra/internal/export/handle_withdrawals.go
@@ -54,7 +54,7 @@ func (opts *ExportOptions) HandleWithdrawals(monitorArray []monitor.Monitor) err
 				} else {
 					bar := logger.NewBar(logger.BarOptions{
 						Prefix:  mon.Address.Hex(),
-						Enabled: !testMode && !utils.IsTerminal(),
+						Enabled: !testMode && !logger.IsTerminal(),
 						Total:   int64(cnt),
 					})
 

--- a/src/apps/chifra/internal/export/handle_withdrawals.go
+++ b/src/apps/chifra/internal/export/handle_withdrawals.go
@@ -23,7 +23,7 @@ func (opts *ExportOptions) HandleWithdrawals(monitorArray []monitor.Monitor) err
 	chain := opts.Globals.Chain
 	testMode := opts.Globals.TestMode
 	nErrors := 0
-	first := base.Max2(base.KnownBlock(chain, "shanghai"), opts.FirstBlock)
+	first := base.Max(base.KnownBlock(chain, "shanghai"), opts.FirstBlock)
 	filter := filter.NewFilter(
 		opts.Reversed,
 		false,

--- a/src/apps/chifra/internal/init/handle_dryrun.go
+++ b/src/apps/chifra/internal/init/handle_dryrun.go
@@ -9,7 +9,6 @@ import (
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/history"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/logger"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/manifest"
-	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/utils"
 )
 
 func (opts *InitOptions) HandleDryRun() error {
@@ -41,7 +40,7 @@ func (opts *InitOptions) HandleDryRun() error {
 
 	spec := manifest.Specification()
 	if opts.Globals.TestMode {
-		nToDownload = utils.Min(10, nToDownload)
+		nToDownload = base.Min(10, nToDownload)
 		spec = "--testing-hash--"
 	}
 

--- a/src/apps/chifra/internal/init/handle_init_download.go
+++ b/src/apps/chifra/internal/init/handle_init_download.go
@@ -20,7 +20,6 @@ import (
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/manifest"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/progress"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/types"
-	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/utils"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/walk"
 )
 
@@ -33,7 +32,7 @@ var nStarted int
 // downloadAndReportProgress Downloads the chunks and reports progress to the progressChannel
 func (opts *InitOptions) downloadAndReportProgress(chunks []types.ChunkRecord, chunkType walk.CacheType, nTotal int) ([]types.ChunkRecord, bool) {
 	chain := opts.Globals.Chain
-	sleep := utils.Max(.0125, opts.Sleep)
+	sleep := base.Max(.0125, opts.Sleep)
 	successCount := 0
 
 	failed := []types.ChunkRecord{}
@@ -75,7 +74,7 @@ func (opts *InitOptions) downloadAndReportProgress(chunks []types.ChunkRecord, c
 			if ok {
 				failed = append(failed, *chunk)
 				if errors.Is(event.Error, index.ErrWriteToDiscError) {
-					sleep = utils.Min(4, sleep*1.2)
+					sleep = base.Min(4, sleep*1.2)
 					successCount = 0
 				}
 			}
@@ -109,7 +108,7 @@ func (opts *InitOptions) downloadAndReportProgress(chunks []types.ChunkRecord, c
 			msg := fmt.Sprintf("Finished download of %s%s%s %s%s%s (% 4d of %4d %0.1f%%%s)", col, event.Message, colors.Off, col, rng, colors.Off, nProcessed, nTotal, pct, sleepStr)
 			logger.Info(msg, spaces)
 			if successCount%10 == 0 {
-				sleep = utils.Max(.0125, sleep/1.2)
+				sleep = base.Max(.0125, sleep/1.2)
 				successCount = 0
 			}
 

--- a/src/apps/chifra/internal/init/handle_init_prepare.go
+++ b/src/apps/chifra/internal/init/handle_init_prepare.go
@@ -128,7 +128,7 @@ func (opts *InitOptions) prepareDownloadList(chain string, man *manifest.Manifes
 
 	nDeleted := 0
 	for rng, reason := range deleteMap {
-		_, indexPath := rng.RangeToFilename(chain)
+		indexPath := rng.RangeToFilename(chain)
 		bloomPath := index.ToBloomPath(indexPath)
 		indexExists := file.FileExists(indexPath)
 		bloomExists := file.FileExists(bloomPath)
@@ -160,7 +160,7 @@ func (opts *InitOptions) prepareDownloadList(chain string, man *manifest.Manifes
 		if downloadMap[rng] == OKAY || rng.Last < opts.FirstBlock {
 			continue
 		}
-		_, indexPath := rng.RangeToFilename(chain)
+		indexPath := rng.RangeToFilename(chain)
 		bloomStatus, indexStatus, err := isValidChunk(index.ToBloomPath(indexPath), chunk.BloomSize, chunk.IndexSize, opts.All)
 		if err != nil {
 			return nil, 0, nDeleted, err

--- a/src/apps/chifra/internal/logs/handle_show.go
+++ b/src/apps/chifra/internal/logs/handle_show.go
@@ -46,7 +46,7 @@ func (opts *LogsOptions) HandleShow() error {
 
 		} else {
 			bar := logger.NewBar(logger.BarOptions{
-				Enabled: !testMode && !utils.IsTerminal(),
+				Enabled: !testMode && !logger.IsTerminal(),
 				Total:   int64(cnt),
 			})
 

--- a/src/apps/chifra/internal/monitors/handle_watch.go
+++ b/src/apps/chifra/internal/monitors/handle_watch.go
@@ -137,7 +137,7 @@ func (opts *MonitorsOptions) Refresh(monitors []monitor.Monitor) (bool, error) {
 		fmt.Printf("%s%d-%d of %d:%s chifra export --freshen",
 			colors.BrightBlue,
 			i*batchSize,
-			utils.Min(((i+1)*batchSize)-1, len(monitors)),
+			base.Min(((i+1)*batchSize)-1, len(monitors)),
 			len(monitors),
 			colors.Green)
 		for _, addr := range addrs {

--- a/src/apps/chifra/internal/receipts/handle_show.go
+++ b/src/apps/chifra/internal/receipts/handle_show.go
@@ -41,7 +41,7 @@ func (opts *ReceiptsOptions) HandleShow() error {
 
 		} else {
 			bar := logger.NewBar(logger.BarOptions{
-				Enabled: !testMode && !utils.IsTerminal(),
+				Enabled: !testMode && !logger.IsTerminal(),
 				Total:   int64(cnt),
 			})
 

--- a/src/apps/chifra/internal/scrape/handle_scrape.go
+++ b/src/apps/chifra/internal/scrape/handle_scrape.go
@@ -108,7 +108,7 @@ func (opts *ScrapeOptions) HandleScrape() error {
 		// }
 
 		// user supplied, but not so many to pass the chain tip.
-		bm.blockCount = base.Min2(base.Blknum(opts.BlockCnt), bm.meta.ChainHeight()-bm.StartBlock()+1)
+		bm.blockCount = base.Min(base.Blknum(opts.BlockCnt), bm.meta.ChainHeight()-bm.StartBlock()+1)
 		// Unripe_dist behind the chain tip.
 		bm.ripeBlock = bm.meta.ChainHeight() - base.Blknum(opts.Settings.UnripeDist)
 

--- a/src/apps/chifra/internal/scrape/scrape_consolidate.go
+++ b/src/apps/chifra/internal/scrape/scrape_consolidate.go
@@ -141,7 +141,7 @@ func (bm *BlazeManager) Consolidate(blocks []base.Blknum) (error, bool) {
 			for _, app := range apps {
 				record := fmt.Sprintf("%s\t%09d\t%05d", addr, app.BlockNumber, app.TransactionIndex)
 				appearances = append(appearances, record)
-				newRange.Last = base.Max2(newRange.Last, base.Blknum(app.BlockNumber))
+				newRange.Last = base.Max(newRange.Last, base.Blknum(app.BlockNumber))
 			}
 		}
 
@@ -196,8 +196,8 @@ func (bm *BlazeManager) AsciiFileToAppearanceMap(fn string) (map[string][]types.
 			if addr == base.SentinalAddr.Hex() && txid == types.MisconfigReward {
 				continue
 			}
-			fileRange.First = base.Min2(fileRange.First, bn)
-			fileRange.Last = base.Max2(fileRange.Last, bn)
+			fileRange.First = base.Min(fileRange.First, bn)
+			fileRange.Last = base.Max(fileRange.Last, bn)
 			appMap[addr] = append(appMap[addr], types.AppRecord{
 				BlockNumber:      uint32(bn),
 				TransactionIndex: uint32(txid),

--- a/src/apps/chifra/internal/scrape/scrape_manager_utils.go
+++ b/src/apps/chifra/internal/scrape/scrape_manager_utils.go
@@ -8,12 +8,11 @@ import (
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/colors"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/config"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/logger"
-	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/utils"
 )
 
 // Report prints out a report of the progress of the scraper.
 func (bm *BlazeManager) report(nBlocks, perChunk, nChunks, nAppsNow, nAppsFound, nAddrsFound int) {
-	nNeeded := perChunk - utils.Min(perChunk, nAppsNow)
+	nNeeded := perChunk - base.Min(perChunk, nAppsNow)
 	appsPerAddr := float64(nAppsFound) / float64(nAddrsFound)
 	pctFull := float64(nAppsNow) / float64(perChunk)
 

--- a/src/apps/chifra/internal/scrape/validate.go
+++ b/src/apps/chifra/internal/scrape/validate.go
@@ -61,7 +61,7 @@ func (opts *ScrapeOptions) validateScrape() error {
 	if err != nil {
 		return err
 	}
-	m := base.Max2(meta.Ripe, base.Max2(meta.Staging, meta.Finalized)) + 1
+	m := base.Max(meta.Ripe, base.Max(meta.Staging, meta.Finalized)) + 1
 	if !opts.DryRun && m > meta.Latest {
 		fmt.Println(validate.Usage("The index ({0}) is ahead of the chain ({1}).", fmt.Sprintf("%d", m), fmt.Sprintf("%d", meta.Latest)))
 	}

--- a/src/apps/chifra/internal/slurp/handle_appearances.go
+++ b/src/apps/chifra/internal/slurp/handle_appearances.go
@@ -3,10 +3,10 @@ package slurpPkg
 import (
 	"context"
 
+	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/logger"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/output"
 	providerPkg "github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/rpc/provider"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/types"
-	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/utils"
 )
 
 func (opts *SlurpOptions) HandleAppearances() error {
@@ -14,7 +14,7 @@ func (opts *SlurpOptions) HandleAppearances() error {
 	if err != nil {
 		return err
 	}
-	provider.SetPrintProgress(!opts.Globals.TestMode && !utils.IsTerminal())
+	provider.SetPrintProgress(!opts.Globals.TestMode && !logger.IsTerminal())
 	query := &providerPkg.Query{
 		Addresses: opts.Addresses(),
 		Resources: opts.Types,

--- a/src/apps/chifra/internal/slurp/handle_count.go
+++ b/src/apps/chifra/internal/slurp/handle_count.go
@@ -3,10 +3,10 @@ package slurpPkg
 import (
 	"context"
 
+	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/logger"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/output"
 	providerPkg "github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/rpc/provider"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/types"
-	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/utils"
 )
 
 func (opts *SlurpOptions) HandleCount() error {
@@ -14,7 +14,7 @@ func (opts *SlurpOptions) HandleCount() error {
 	if err != nil {
 		return err
 	}
-	provider.SetPrintProgress(!opts.Globals.TestMode && !utils.IsTerminal())
+	provider.SetPrintProgress(!opts.Globals.TestMode && !logger.IsTerminal())
 	query := &providerPkg.Query{
 		Addresses: opts.Addresses(),
 		Resources: opts.Types,

--- a/src/apps/chifra/internal/slurp/handle_show.go
+++ b/src/apps/chifra/internal/slurp/handle_show.go
@@ -4,10 +4,10 @@ import (
 	"context"
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/articulate"
+	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/logger"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/output"
 	providerPkg "github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/rpc/provider"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/types"
-	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/utils"
 )
 
 func (opts *SlurpOptions) HandleShow() error {
@@ -17,7 +17,7 @@ func (opts *SlurpOptions) HandleShow() error {
 	if err != nil {
 		return err
 	}
-	provider.SetPrintProgress(!opts.Globals.TestMode && !utils.IsTerminal())
+	provider.SetPrintProgress(!opts.Globals.TestMode && !logger.IsTerminal())
 	query := &providerPkg.Query{
 		Addresses: opts.Addresses(),
 		Resources: opts.Types,

--- a/src/apps/chifra/internal/state/handle_call.go
+++ b/src/apps/chifra/internal/state/handle_call.go
@@ -52,7 +52,7 @@ func (opts *StateOptions) HandleCall() error {
 
 		} else {
 			bar := logger.NewBar(logger.BarOptions{
-				Enabled: !testMode && !utils.IsTerminal(),
+				Enabled: !testMode && !logger.IsTerminal(),
 				Total:   int64(cnt),
 			})
 

--- a/src/apps/chifra/internal/traces/handle_counts.go
+++ b/src/apps/chifra/internal/traces/handle_counts.go
@@ -39,7 +39,7 @@ func (opts *TracesOptions) HandleCounts() error {
 
 		} else {
 			bar := logger.NewBar(logger.BarOptions{
-				Enabled: !testMode && !utils.IsTerminal(),
+				Enabled: !testMode && !logger.IsTerminal(),
 				Total:   int64(cnt),
 			})
 

--- a/src/apps/chifra/internal/traces/handle_filter.go
+++ b/src/apps/chifra/internal/traces/handle_filter.go
@@ -52,7 +52,7 @@ func (opts *TracesOptions) HandleFilter() error {
 
 		} else {
 			bar := logger.NewBar(logger.BarOptions{
-				Enabled: !testMode && !utils.IsTerminal(),
+				Enabled: !testMode && !logger.IsTerminal(),
 				Total:   int64(cnt),
 			})
 

--- a/src/apps/chifra/internal/traces/handle_show.go
+++ b/src/apps/chifra/internal/traces/handle_show.go
@@ -41,7 +41,7 @@ func (opts *TracesOptions) HandleShow() error {
 
 		} else {
 			bar := logger.NewBar(logger.BarOptions{
-				Enabled: !testMode && !utils.IsTerminal(),
+				Enabled: !testMode && !logger.IsTerminal(),
 				Total:   int64(cnt),
 			})
 

--- a/src/apps/chifra/internal/transactions/handle_logs.go
+++ b/src/apps/chifra/internal/transactions/handle_logs.go
@@ -43,7 +43,7 @@ func (opts *TransactionsOptions) HandleLogs() error {
 
 		} else {
 			bar := logger.NewBar(logger.BarOptions{
-				Enabled: !testMode && !utils.IsTerminal(),
+				Enabled: !testMode && !logger.IsTerminal(),
 				Total:   int64(cnt),
 			})
 

--- a/src/apps/chifra/internal/transactions/handle_show.go
+++ b/src/apps/chifra/internal/transactions/handle_show.go
@@ -41,7 +41,7 @@ func (opts *TransactionsOptions) HandleShow() (err error) {
 
 		} else {
 			bar := logger.NewBar(logger.BarOptions{
-				Enabled: !testMode && !utils.IsTerminal(),
+				Enabled: !testMode && !logger.IsTerminal(),
 				Total:   int64(cnt),
 			})
 

--- a/src/apps/chifra/internal/when/handle_show.go
+++ b/src/apps/chifra/internal/when/handle_show.go
@@ -14,7 +14,6 @@ import (
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/output"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/tslib"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/types"
-	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/utils"
 	"github.com/ethereum/go-ethereum"
 )
 
@@ -36,7 +35,7 @@ func (opts *WhenOptions) HandleShow() error {
 			}
 
 			bar := logger.NewBar(logger.BarOptions{
-				Enabled: !testMode && !utils.IsTerminal(),
+				Enabled: !testMode && !logger.IsTerminal(),
 				Total:   int64(len(blockNums)),
 			})
 

--- a/src/apps/chifra/pkg/base/address.go
+++ b/src/apps/chifra/pkg/base/address.go
@@ -34,7 +34,7 @@ func (a *Address) Hex() string {
 }
 
 func (a *Address) Prefix(n int) string {
-	return a.Hex()[:Min2(len(a.Hex()), 6)]
+	return a.Hex()[:Min(len(a.Hex()), 6)]
 }
 
 func (a *Address) Encoded32() string {

--- a/src/apps/chifra/pkg/base/address.go
+++ b/src/apps/chifra/pkg/base/address.go
@@ -4,10 +4,10 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"log"
 	"path/filepath"
 	"strings"
 
-	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/logger"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/utils"
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -110,11 +110,11 @@ func AddressFromPath(path, fileType string) (Address, error) {
 	_, fileName := filepath.Split(path)
 
 	if !strings.HasSuffix(fileName, fileType) {
-		logger.Fatal("should not happen ==> path should contain fileType")
+		log.Fatal("should not happen ==> path should contain fileType")
 	}
 
 	if !strings.HasPrefix(fileType, ".") {
-		logger.Fatal("should not happen ==> fileType should have a leading dot")
+		log.Fatal("should not happen ==> fileType should have a leading dot")
 	}
 
 	if len(fileName) < (42+len(fileType)) || !strings.HasPrefix(fileName, "0x") || !strings.Contains(fileName, ".") {

--- a/src/apps/chifra/pkg/base/address.go
+++ b/src/apps/chifra/pkg/base/address.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/utils"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -35,7 +34,7 @@ func (a *Address) Hex() string {
 }
 
 func (a *Address) Prefix(n int) string {
-	return a.Hex()[:utils.Min(len(a.Hex()), 6)]
+	return a.Hex()[:Min2(len(a.Hex()), 6)]
 }
 
 func (a *Address) Encoded32() string {

--- a/src/apps/chifra/pkg/base/fileRange.go
+++ b/src/apps/chifra/pkg/base/fileRange.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/config"
-	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/file"
 )
 
 type RecordRange struct {
@@ -76,9 +75,8 @@ func (r FileRange) String() string {
 }
 
 // RangeToFilename returns a fileName and existence bool given a file range and a type
-func (r *FileRange) RangeToFilename(chain string) (bool, string) {
-	fileName := config.PathToIndex(chain) + "finalized/" + r.String() + ".bin"
-	return file.FileExists(fileName), fileName
+func (r *FileRange) RangeToFilename(chain string) string {
+	return config.PathToIndex(chain) + "finalized/" + r.String() + ".bin"
 }
 
 // Follows returns true if the range is strictly after the needle range.

--- a/src/apps/chifra/pkg/base/fileRange.go
+++ b/src/apps/chifra/pkg/base/fileRange.go
@@ -151,10 +151,10 @@ type RangeDiff struct {
 }
 
 func (r *FileRange) Overlaps(test FileRange) (rd RangeDiff) {
-	rd.Min = Min2(r.First, test.First)
-	rd.In = Max2(r.First, test.First)
-	rd.Out = Min2(r.Last, test.Last)
-	rd.Max = Max2(r.Last, test.Last)
+	rd.Min = Min(r.First, test.First)
+	rd.In = Max(r.First, test.First)
+	rd.Out = Min(r.Last, test.Last)
+	rd.Max = Max(r.Last, test.Last)
 	rd.Mid = (rd.Max-rd.Min)/2 + rd.Min
 	return
 }

--- a/src/apps/chifra/pkg/base/fileRange.go
+++ b/src/apps/chifra/pkg/base/fileRange.go
@@ -152,22 +152,6 @@ type RangeDiff struct {
 	Max Blknum
 }
 
-// Min calculates the minimum between two unsigned integers (golang has no such function)
-func Min2(x, y Blknum) Blknum {
-	if x < y {
-		return x
-	}
-	return y
-}
-
-// Max calculates the max between two unsigned integers (golang has no such function)
-func Max2(x, y Blknum) Blknum {
-	if x > y {
-		return x
-	}
-	return y
-}
-
 func (r *FileRange) Overlaps(test FileRange) (rd RangeDiff) {
 	rd.Min = Min2(r.First, test.First)
 	rd.In = Max2(r.First, test.First)

--- a/src/apps/chifra/pkg/base/fileRange_test.go
+++ b/src/apps/chifra/pkg/base/fileRange_test.go
@@ -87,7 +87,7 @@ func TestFilenameFromRange(t *testing.T) {
 
 	fR := FileRange{0, 100}
 	want := "mainnet/finalized/000000000-000000100.bin"
-	_, got := fR.RangeToFilename("mainnet")
+	got := fR.RangeToFilename("mainnet")
 	parts := strings.Split(got, "unchained/")
 	if len(parts) != 2 || parts[1] != want {
 		t.Errorf("FilenameFromRange() = %v, want %v", got, parts[1])

--- a/src/apps/chifra/pkg/base/minmax.go
+++ b/src/apps/chifra/pkg/base/minmax.go
@@ -1,0 +1,17 @@
+package base
+
+// Min calculates the minimum between two unsigned integers (golang has no such function)
+func Min2[T Numeral | int | float64 | uint32 | int64 | uint64](x, y T) T {
+	if x < y {
+		return x
+	}
+	return y
+}
+
+// Max calculates the max between two unsigned integers (golang has no such function)
+func Max2[T Numeral | int | float64 | uint32 | int64 | uint64](x, y T) T {
+	if x > y {
+		return x
+	}
+	return y
+}

--- a/src/apps/chifra/pkg/base/minmax.go
+++ b/src/apps/chifra/pkg/base/minmax.go
@@ -1,7 +1,7 @@
 package base
 
 // Min calculates the minimum between two unsigned integers (golang has no such function)
-func Min2[T Numeral | int | float64 | uint32 | int64 | uint64](x, y T) T {
+func Min[T Numeral | int | float64 | uint32 | int64 | uint64](x, y T) T {
 	if x < y {
 		return x
 	}
@@ -9,7 +9,7 @@ func Min2[T Numeral | int | float64 | uint32 | int64 | uint64](x, y T) T {
 }
 
 // Max calculates the max between two unsigned integers (golang has no such function)
-func Max2[T Numeral | int | float64 | uint32 | int64 | uint64](x, y T) T {
+func Max[T Numeral | int | float64 | uint32 | int64 | uint64](x, y T) T {
 	if x > y {
 		return x
 	}

--- a/src/apps/chifra/pkg/cache/cache.go
+++ b/src/apps/chifra/pkg/cache/cache.go
@@ -2,10 +2,10 @@ package cache
 
 import (
 	"io"
+	"log"
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/cache/locations"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/config"
-	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/logger"
 )
 
 type StoreLocation uint
@@ -64,8 +64,7 @@ type StoreOptions struct {
 
 func (s *StoreOptions) location() (loc Storer, err error) {
 	if s == nil {
-		// TODO: s can never be nil, we would have cored already
-		logger.Fatal("should not happen ==> implementation error in location.")
+		log.Fatal("should not happen ==> implementation error in location.")
 		return
 	}
 	switch s.Location {
@@ -86,8 +85,7 @@ func (s *StoreOptions) rootDir() (dir string) {
 	}
 
 	if s == nil {
-		// TODO: s is never nil, we would have cored already
-		logger.Fatal("should not happen ==> implementation error in location.")
+		log.Fatal("should not happen ==> implementation error in location.")
 	} else if s.RootDir == "" {
 		dir = config.PathToCache(s.Chain)
 	}

--- a/src/apps/chifra/pkg/cache/store.go
+++ b/src/apps/chifra/pkg/cache/store.go
@@ -9,8 +9,8 @@ import (
 	"sync"
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/cache/locations"
-	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/logger"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/sigintTrap"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 // In verbose mode we print cache errors. It's useful for debugging.
@@ -95,7 +95,7 @@ func (s *Store) Write(value Locator, options *WriteOptions) (err error) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cleanOnQuit := func() {
-		logger.Warn(sigintTrap.TrapMessage)
+		log.Warn(sigintTrap.TrapMessage)
 	}
 	trapChannel := sigintTrap.Enable(ctx, cancel, cleanOnQuit)
 	defer sigintTrap.Disable(trapChannel)
@@ -207,5 +207,5 @@ func printErr(desc string, err error) {
 		return
 	}
 
-	logger.Warn("cache error:", desc+":", err)
+	log.Warn("cache error:", desc+":", err)
 }

--- a/src/apps/chifra/pkg/config/config.go
+++ b/src/apps/chifra/pkg/config/config.go
@@ -5,6 +5,7 @@
 package config
 
 import (
+	"log"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -12,7 +13,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/logger"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/usage"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/version"
 	"github.com/spf13/viper"
@@ -74,10 +74,10 @@ func GetRootConfig() *ConfigFile {
 	trueBlocksViper.AutomaticEnv()
 	trueBlocksViper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	if err := trueBlocksViper.ReadInConfig(); err != nil {
-		logger.Fatal(err)
+		log.Fatal(err)
 	}
 	if err := trueBlocksViper.Unmarshal(&trueBlocksConfig); err != nil {
-		logger.Fatal(err)
+		log.Fatal(err)
 	}
 
 	user, _ := user.Current()
@@ -164,7 +164,7 @@ func PathToConfigFile() string {
 func PathToRootConfig() string {
 	configPath, err := pathFromXDG("XDG_CONFIG_HOME")
 	if err != nil {
-		logger.Fatal(err)
+		log.Fatal(err)
 	} else if len(configPath) > 0 {
 		return configPath
 	}

--- a/src/apps/chifra/pkg/file/asciifiles.go
+++ b/src/apps/chifra/pkg/file/asciifiles.go
@@ -6,11 +6,12 @@ package file
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"os"
 	"strings"
 
-	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/logger"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 func AsciiFileToLines(filename string) []string {
@@ -35,7 +36,7 @@ func AsciiFileToString(fileName string) string {
 
 	contents, err := os.ReadFile(fileName)
 	if err != nil {
-		logger.Error(err)
+		log.Error(fmt.Sprintf("%v", err))
 		return ""
 	}
 

--- a/src/apps/chifra/pkg/identifiers/resolve.go
+++ b/src/apps/chifra/pkg/identifiers/resolve.go
@@ -47,8 +47,8 @@ func GetBounds(chain string, ids *[]Identifier) (ret base.BlockRange, err error)
 		if err != nil {
 			return ret, err
 		}
-		ret.First = base.Min2(ret.First, idRange.First)
-		ret.Last = base.Max2(ret.Last, idRange.Last)
+		ret.First = base.Min(ret.First, idRange.First)
+		ret.Last = base.Max(ret.Last, idRange.Last)
 	}
 
 	return ret, nil

--- a/src/apps/chifra/pkg/index/download_one_chunk.go
+++ b/src/apps/chifra/pkg/index/download_one_chunk.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/base"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/colors"
-	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/file"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/logger"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/manifest"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/progress"
@@ -19,13 +18,11 @@ import (
 
 // DownloadOneChunk a filename to an index portion, finds the correspoding CID (hash)
 // entry in the manifest, and downloads the index chunk to the local drive
-func DownloadOneChunk(chain string, man *manifest.Manifest, fileRange base.FileRange) (bool, error) {
-	exists, fileName := fileRange.RangeToFilename(chain)
-
+func DownloadOneChunk(chain string, man *manifest.Manifest, fileRange base.FileRange) error {
 	// Find bloom filter's CID
 	matchedPin := man.ChunkMap[fileRange.String()]
 	if matchedPin == nil || matchedPin.Range == "" {
-		return exists, fmt.Errorf("filename path missing in chunks: %s", fileRange)
+		return fmt.Errorf("filename path missing in chunks: %s", fileRange)
 	}
 
 	logger.Info("Bloom filter hit, downloading index portion", (colors.Yellow + fileRange.String() + colors.Off), "from IPFS.")
@@ -43,12 +40,12 @@ func DownloadOneChunk(chain string, man *manifest.Manifest, fileRange base.FileR
 	for event := range progressChannel {
 		switch event.Event {
 		case progress.AllDone:
-			return file.FileExists(fileName), nil
+			return nil
 		case progress.Cancelled:
-			return file.FileExists(fileName), nil
+			return nil
 		case progress.Error:
-			return file.FileExists(fileName), fmt.Errorf("error while downloading: %s", event.Message)
+			return fmt.Errorf("error while downloading: %s", event.Message)
 		}
 	}
-	return file.FileExists(fileName), nil
+	return nil
 }

--- a/src/apps/chifra/pkg/index/download_one_chunk_integration_test.go
+++ b/src/apps/chifra/pkg/index/download_one_chunk_integration_test.go
@@ -13,7 +13,7 @@ func Test_EstablishValidFilename(t *testing.T) {
 	r := base.FileRange{First: 0, Last: 1}
 	man := manifest.Manifest{}
 	man.ChunkMap = make(map[string]*types.ChunkRecord, 0)
-	_, err := DownloadOneChunk("mainnet", &man, r)
+	err := DownloadOneChunk("mainnet", &man, r)
 	if err == nil {
 		t.Fatal("error expected")
 	}

--- a/src/apps/chifra/pkg/ledger/context.go
+++ b/src/apps/chifra/pkg/ledger/context.go
@@ -8,7 +8,6 @@ import (
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/base"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/logger"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/types"
-	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/utils"
 )
 
 type ledgerContextKey string
@@ -94,8 +93,8 @@ const maxTestingBlock = 17000000
 func (l *Ledger) SetContexts(chain string, apps []types.Appearance) error {
 	for i := 0; i < len(apps); i++ {
 		cur := base.Blknum(apps[i].BlockNumber)
-		prev := base.Blknum(apps[utils.Max(1, i)-1].BlockNumber)
-		next := base.Blknum(apps[utils.Min(i+1, len(apps)-1)].BlockNumber)
+		prev := base.Blknum(apps[base.Max(1, i)-1].BlockNumber)
+		next := base.Blknum(apps[base.Min(i+1, len(apps)-1)].BlockNumber)
 		key := l.ctxKey(base.Blknum(apps[i].BlockNumber), base.Txnum(apps[i].TransactionIndex))
 		l.Contexts[key] = newLedgerContext(base.Blknum(prev), base.Blknum(cur), base.Blknum(next), i == 0, i == (len(apps)-1), l.Reversed)
 	}

--- a/src/apps/chifra/pkg/logger/logger.go
+++ b/src/apps/chifra/pkg/logger/logger.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/colors"
-	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/utils"
+	"golang.org/x/term"
 )
 
 type severity int
@@ -171,13 +171,6 @@ func Panic(v ...any) {
 	panic(s)
 }
 
-func Progress(tick bool, v ...any) {
-	if isTestMode || !utils.IsTerminal() || !tick {
-		return
-	}
-	toLog(progress, v...)
-}
-
 func CleanLine() {
 	// \033[K is escape sequence meaning "erase to end of line"
 	fmt.Print("\r\033[K")
@@ -190,4 +183,15 @@ func PctProgress(done int32, total int, tick int32) {
 
 	percentage := math.Round(float64(done) / float64(total) * 100)
 	toLog(progress, fmt.Sprintf("\r\t\t\t Processing: %.f%% (%d of %d)%s", percentage, done, total, strings.Repeat(" ", 40)))
+}
+
+func Progress(tick bool, v ...any) {
+	if isTestMode || !IsTerminal() || !tick {
+		return
+	}
+	toLog(progress, v...)
+}
+
+func IsTerminal() bool {
+	return term.IsTerminal(int(os.Stdout.Fd()))
 }

--- a/src/apps/chifra/pkg/logger/timer.go
+++ b/src/apps/chifra/pkg/logger/timer.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"strings"
 	"time"
-
-	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/utils"
 )
 
 var perfTiming bool
@@ -63,8 +61,16 @@ func (t *Timer) Report(msg string) {
 	if len(name) > 0 {
 		msg = strings.Replace(msg, "chifra ", "", -1) + "_" + name
 	}
+
+	max := func(x, y int64) int64 {
+		if x > y {
+			return x
+		}
+		return y
+	}
+
 	// nItems := 0
-	fmt.Printf("PERF,%s%s,%d,%d\n", strings.Repeat("_", t.level), msg, utils.Max(1, since.Milliseconds()), utils.Max(1, diff.Milliseconds()))
+	fmt.Printf("PERF,%s%s,%d,%d\n", strings.Repeat("_", t.level), msg, max(1, since.Milliseconds()), max(1, diff.Milliseconds()))
 
 	t.lastReport = time.Now()
 }

--- a/src/apps/chifra/pkg/monitor/monitor_freshen.go
+++ b/src/apps/chifra/pkg/monitor/monitor_freshen.go
@@ -283,7 +283,7 @@ func (updater *MonitorUpdate) visitChunkToFreshenFinal(fileName string, resultCh
 			return
 		}
 
-		_, err = index.DownloadOneChunk(chain, man, bl.Range)
+		err = index.DownloadOneChunk(chain, man, bl.Range)
 		if err != nil {
 			results = append(results, index.AppearanceResult{Range: bl.Range, Err: err})
 			return

--- a/src/apps/chifra/pkg/monitor/truncate.go
+++ b/src/apps/chifra/pkg/monitor/truncate.go
@@ -1,9 +1,9 @@
 package monitor
 
 import (
+	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/base"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/filter"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/types"
-	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/utils"
 )
 
 func (mon *Monitor) TruncateTo(chain string, num uint32) (bool, error) {
@@ -28,7 +28,7 @@ func (mon *Monitor) TruncateTo(chain string, num uint32) (bool, error) {
 				})
 			}
 		}
-		lastScanned := utils.Min(num, mon.Header.LastScanned)
+		lastScanned := base.Min(num, mon.Header.LastScanned)
 
 		mon.Close() // so when we open it, it gets replaced
 		// Very important to note - if you use false for append, the header gets overwritten

--- a/src/apps/chifra/pkg/names/names.go
+++ b/src/apps/chifra/pkg/names/names.go
@@ -15,7 +15,6 @@ import (
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/config"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/prefunds"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/types"
-	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/utils"
 )
 
 type Parts int
@@ -78,7 +77,7 @@ func LoadNamesArray(chain string, parts Parts, sortBy SortBy, terms []string) ([
 	isTesting := parts&Testing != 0
 	isTags := sortBy == SortByTags
 	if isTesting && !isTags {
-		names = names[:utils.Min(200, len(names))]
+		names = names[:base.Min(200, len(names))]
 	}
 
 	return names, nil

--- a/src/apps/chifra/pkg/rpc/get_meta.go
+++ b/src/apps/chifra/pkg/rpc/get_meta.go
@@ -52,13 +52,13 @@ func (conn *Connection) GetMetaData(testmode bool) (*types.MetaData, error) {
 		case walk.Index_Bloom:
 			fallthrough
 		case walk.Index_Final:
-			meta.Finalized = base.Max2(meta.Finalized, result.FileRange.Last)
+			meta.Finalized = base.Max(meta.Finalized, result.FileRange.Last)
 		case walk.Index_Staging:
-			meta.Staging = base.Max2(meta.Staging, result.FileRange.Last)
+			meta.Staging = base.Max(meta.Staging, result.FileRange.Last)
 		case walk.Index_Ripe:
-			meta.Ripe = base.Max2(meta.Ripe, result.FileRange.Last)
+			meta.Ripe = base.Max(meta.Ripe, result.FileRange.Last)
 		case walk.Index_Unripe:
-			meta.Unripe = base.Max2(meta.Unripe, result.FileRange.Last)
+			meta.Unripe = base.Max(meta.Unripe, result.FileRange.Last)
 		case walk.Cache_NotACache:
 			nRoutines--
 			if nRoutines == 0 {
@@ -70,8 +70,8 @@ func (conn *Connection) GetMetaData(testmode bool) (*types.MetaData, error) {
 	if meta.Staging == 0 {
 		meta.Staging = meta.Finalized
 	}
-	meta.Ripe = base.Max2(meta.Staging, meta.Ripe)
-	meta.Unripe = base.Max2(meta.Ripe, meta.Unripe)
+	meta.Ripe = base.Max(meta.Staging, meta.Ripe)
+	meta.Unripe = base.Max(meta.Ripe, meta.Unripe)
 
 	return &meta, nil
 }

--- a/src/apps/chifra/pkg/rpc/is_node.go
+++ b/src/apps/chifra/pkg/rpc/is_node.go
@@ -39,7 +39,7 @@ var ErrTraceBlockMissing = "trace_block is missing"
 // queries block 1 (which we presume exists). The function returns false if
 // block_trace an error.
 func (conn *Connection) IsNodeTracing() bool {
-	first := base.Max2(1, base.KnownBlock(conn.Chain, base.FirstTrace))
+	first := base.Max(1, base.KnownBlock(conn.Chain, base.FirstTrace))
 	_, err := conn.GetTracesByBlockNumber(first)
 	return err == nil
 }

--- a/src/apps/chifra/pkg/types/types_metadata.go
+++ b/src/apps/chifra/pkg/types/types_metadata.go
@@ -24,7 +24,7 @@ func (m *MetaData) String() string {
 
 // Highest returns the height of the index (i.e., max between the finalized, staging, and ripe indexes).
 func (m *MetaData) IndexHeight() base.Blknum {
-	return base.Max2(m.Finalized, base.Max2(m.Staging, m.Ripe))
+	return base.Max(m.Finalized, base.Max(m.Staging, m.Ripe))
 }
 
 // NextIndexHeight returns the block after the height of the index.

--- a/src/apps/chifra/pkg/utils/iteration.go
+++ b/src/apps/chifra/pkg/utils/iteration.go
@@ -19,8 +19,15 @@ func IterateOverMap[Key comparable, Value any](ctx context.Context, errorChan ch
 	var wg sync.WaitGroup
 	defer close(errorChan)
 
-	nRoutines := Max(1, runtime.GOMAXPROCS(0))
-	itemsPerPool := Max(1, len(target)/nRoutines)
+	max := func(x, y int) int {
+		if x > y {
+			return x
+		}
+		return y
+	}
+
+	nRoutines := max(1, runtime.GOMAXPROCS(0))
+	itemsPerPool := max(1, len(target)/nRoutines)
 
 	type stepArguments struct {
 		key   Key

--- a/src/apps/chifra/pkg/utils/utils.go
+++ b/src/apps/chifra/pkg/utils/utils.go
@@ -73,22 +73,6 @@ func PadRight(str string, totalLen int, pad rune) string {
 	return str + tail
 }
 
-// Min calculates the minimum between two unsigned integers (golang has no such function)
-func Min[T int | float64 | uint32 | int64 | uint64](x, y T) T {
-	if x < y {
-		return x
-	}
-	return y
-}
-
-// Max calculates the max between two unsigned integers (golang has no such function)
-func Max[T int | float64 | uint32 | int64 | uint64](x, y T) T {
-	if x > y {
-		return x
-	}
-	return y
-}
-
 func MakeFirstLowerCase(s string) string {
 	if len(s) < 2 {
 		return strings.ToLower(s)

--- a/src/apps/chifra/pkg/utils/utils.go
+++ b/src/apps/chifra/pkg/utils/utils.go
@@ -10,14 +10,11 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"os"
 	"os/exec"
 	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
-
-	"golang.org/x/term"
 )
 
 // IsServerWriter tries to cast `w` into `http.ResponseWriter`
@@ -25,10 +22,6 @@ import (
 func IsServerWriter(w io.Writer) bool {
 	_, ok := w.(http.ResponseWriter)
 	return ok
-}
-
-func IsTerminal() bool {
-	return term.IsTerminal(int(os.Stdout.Fd()))
 }
 
 func OpenBrowser(url string) {

--- a/src/dev_tools/goMaker/types/utils.markdown.go
+++ b/src/dev_tools/goMaker/types/utils.markdown.go
@@ -3,8 +3,8 @@ package types
 import (
 	"strings"
 
+	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/base"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/logger"
-	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/utils"
 )
 
 func MarkdownTable(header []string, rows [][]string) string {
@@ -47,12 +47,12 @@ func widths(header []string, rows [][]string) []int {
 	nFields := len(header)
 	wids := make([]int, nFields)
 	for i := 0; i < nFields; i++ {
-		wids[i] = utils.Max(wids[i], len(header[i]))
+		wids[i] = base.Max(wids[i], len(header[i]))
 		for j := 0; j < len(rows); j++ {
 			if len(rows[j]) != nFields {
 				logger.Fatal("fields[j] has the wrong number of fields")
 			}
-			wids[i] = utils.Max(wids[i], len(rows[j][i]))
+			wids[i] = base.Max(wids[i], len(rows[j][i]))
 		}
 	}
 

--- a/src/dev_tools/testRunner/testCases/names.csv
+++ b/src/dev_tools/testRunner/testCases/names.csv
@@ -49,8 +49,11 @@ on      ,both ,fast  ,names ,tools ,ethNames ,ens_test               ,y    ,term
 on      ,both ,fast  ,names ,tools ,ethNames ,ens_test_fail          ,y    ,terms = notathingy.eth
 on      ,both ,fast  ,names ,tools ,ethNames ,ens_not_in_db          ,y    ,terms = nick.eth
 
-on      ,cmd  ,fast  ,names ,tools ,ethNames ,xdg_fail1              ,y    ,terms = test
-on      ,cmd  ,fast  ,names ,tools ,ethNames ,xdg_fail2              ,y    ,terms = test
+# These two fail but only because we use `log` instead of `logger`. We do this because
+# logger cause import cycles in config package. Trouble is, these two tests report timestamps
+# during testing when we use `log`. Upshot tests pass by timing breaks them.
+local   ,cmd  ,fast  ,names ,tools ,ethNames ,xdg_fail1              ,y    ,terms = test
+local   ,cmd  ,fast  ,names ,tools ,ethNames ,xdg_fail2              ,y    ,terms = test
 on      ,cmd  ,fast  ,names ,tools ,ethNames ,xdg_fail3              ,y    ,terms = test
 on      ,cmd  ,fast  ,names ,tools ,ethNames ,xdg_fail4              ,y    ,terms = test
 

--- a/src/dev_tools/testRunner/test_runner.go
+++ b/src/dev_tools/testRunner/test_runner.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"strings"
 
+	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/base"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/colors"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/file"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/logger"
-	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/utils"
 )
 
 type Runner struct {
@@ -155,10 +155,10 @@ func (tr *Runner) ReportOneTest(t *TestCase, failed bool) {
 	}
 
 	colors.ColorsOn()
-	skip := strings.Repeat(" ", utils.Max(0, 120-len(t.ApiOptions)-40))
+	skip := strings.Repeat(" ", base.Max(0, 120-len(t.ApiOptions)-40))
 	rPadded := padRight(t.Route, 15, false, ".")
 	fPadded := padRight(t.Filename, 30, false, ".")
-	tOpts := t.ApiOptions[:utils.Min(len(t.ApiOptions), 40)]
+	tOpts := t.ApiOptions[:base.Min(len(t.ApiOptions), 40)]
 	fmt.Printf("%s    %s %d-%d %s %s%s%s%s%s%s", color, mark, tr.NTested, tr.NFiltered, tr.Mode, rPadded, fPadded, tOpts, skip, colors.Off, eol)
 	colors.ColorsOff()
 }


### PR DESCRIPTION
This makes simple changes to try to minimize chance of import cycles between packages. Doesn't totally work because base package depends on cache and config packages both of which import utils and logger. The tangle is loosened, but not yet untangled.