### PR TITLE
Move scrape.pid to temp dir

### DIFF
--- a/src/apps/chifra/internal/scrape/handle_show.go
+++ b/src/apps/chifra/internal/scrape/handle_show.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/base"
@@ -42,7 +41,7 @@ func (opts *ScrapeOptions) HandleScrape() error {
 	chain := opts.Globals.Chain
 	testMode := opts.Globals.TestMode
 	defer func() {
-		pidPath := filepath.Join(config.PathToCache(chain), "tmp/scrape.pid")
+		pidPath := opts.getPidFilePath()
 		_ = os.Remove(pidPath)
 	}()
 


### PR DESCRIPTION
The motivation for this change was running scraper inside Docker, but I think it improves chifra runnig outside Docker, too.

Very, very rarely (after Ctrl-C fix) the `.pid` file was left after scraper had been killed. Moving the file to `/tmp` fixes the problem for Docker (because any directory not mounted to the host filesystem is ephemeral), but there's no guarantee that if running directly the OS will empty `/tmp`. 

The code I added tries to use so called "variable directory" which is guaranteed to be emptied by the OS: https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch03s15.html

For Linux, it's `/run/$UID`, for Mac `/usr/local/var/run`. If the directory doesn't exist, we fall back to `/tmp`.