### PR TITLE
DO NOT MERGE - Initial windows support

### DIFF
--- a/scripts/go-mod-tidy.bat
+++ b/scripts/go-mod-tidy.bat
@@ -8,8 +8,11 @@ set ROOT_DIR=%SCRIPT_DIR%\..
 
 :: Find all go.mod files and tidy them
 cd /d %ROOT_DIR%\examples\balanceChart    && go mod tidy
+cd /d %ROOT_DIR%\examples\cancelContext   && go mod tidy
 cd /d %ROOT_DIR%\examples\findFirst       && go mod tidy
+cd /d %ROOT_DIR%\examples\nameManager     && go mod tidy
 cd /d %ROOT_DIR%\examples\simple          && go mod tidy
+cd /d %ROOT_DIR%\examples\withStreaming   && go mod tidy
 cd /d %ROOT_DIR%\src\apps\chifra          && go mod tidy
 cd /d %ROOT_DIR%\src\dev_tools\goMaker    && go mod tidy
 cd /d %ROOT_DIR%\src\dev_tools\sdkFuzzer  && go mod tidy

--- a/scripts/go-mod-tidy.bat
+++ b/scripts/go-mod-tidy.bat
@@ -1,0 +1,19 @@
+@echo off
+setlocal
+
+:: Get the directory where the script is located
+set SCRIPT_DIR_BACKSLASH=%~dp0
+set SCRIPT_DIR=%script_dir_backslash:~0,-1%
+set ROOT_DIR=%SCRIPT_DIR%\..
+
+:: Find all go.mod files and tidy them
+cd /d %ROOT_DIR%\examples\balanceChart    && go mod tidy
+cd /d %ROOT_DIR%\examples\findFirst       && go mod tidy
+cd /d %ROOT_DIR%\examples\simple          && go mod tidy
+cd /d %ROOT_DIR%\src\apps\chifra          && go mod tidy
+cd /d %ROOT_DIR%\src\dev_tools\goMaker    && go mod tidy
+cd /d %ROOT_DIR%\src\dev_tools\sdkFuzzer  && go mod tidy
+cd /d %ROOT_DIR%\src\dev_tools\testRunner && go mod tidy
+
+:: Return to the original directory and exit
+exit /b

--- a/scripts/go-work-sync.bat
+++ b/scripts/go-work-sync.bat
@@ -13,8 +13,11 @@ echo go 1.22 >> "%GO_WORK_FILE%"
 
 :: Find all go.mod files in the src directory and add their directories to go.work
 cd %ROOT_DIR% && go work use .\examples\balanceChart
+cd %ROOT_DIR% && go work use .\examples\cancelContext
 cd %ROOT_DIR% && go work use .\examples\findFirst
+cd %ROOT_DIR% && go work use .\examples\nameManager
 cd %ROOT_DIR% && go work use .\examples\simple
+cd %ROOT_DIR% && go work use .\examples\withStreaming
 cd %ROOT_DIR% && go work use .\src\apps\chifra
 cd %ROOT_DIR% && go work use .\src\dev_tools\goMaker
 cd %ROOT_DIR% && go work use .\src\dev_tools\sdkFuzzer

--- a/scripts/go-work-sync.bat
+++ b/scripts/go-work-sync.bat
@@ -1,0 +1,35 @@
+@echo off
+setlocal
+
+:: Get the directory where the script is located
+set SCRIPT_DIR_BACKSLASH=%~dp0
+set SCRIPT_DIR=%script_dir_backslash:~0,-1%
+set ROOT_DIR=%SCRIPT_DIR%\..
+
+:: Regenerate the go.work file
+set GO_WORK_FILE=%ROOT_DIR%\go.work
+echo // Go Version > "%GO_WORK_FILE%"
+echo go 1.22 >> "%GO_WORK_FILE%"
+
+:: Find all go.mod files in the src directory and add their directories to go.work
+cd %ROOT_DIR% && go work use .\examples\balanceChart
+cd %ROOT_DIR% && go work use .\examples\findFirst
+cd %ROOT_DIR% && go work use .\examples\simple
+cd %ROOT_DIR% && go work use .\src\apps\chifra
+cd %ROOT_DIR% && go work use .\src\dev_tools\goMaker
+cd %ROOT_DIR% && go work use .\src\dev_tools\sdkFuzzer
+cd %ROOT_DIR% && go work use .\src\dev_tools\testRunner
+
+:: Run go work sync
+cd /d %ROOT_DIR% && go work sync
+
+:: Display the contents of go.work
+echo Created go.work with these contents.
+type "%GO_WORK_FILE%"
+
+:: Run go-mod-tidy script
+call "%SCRIPT_DIR%\go-mod-tidy.bat"
+
+:: Return to the original directory and exit
+cd /d "%SCRIPT_DIR%"
+exit /b

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,7 +17,6 @@ find_package(Python COMPONENTS Interpreter Development)
 # ----------------------------------------------------------------------------------------
 message(STATUS "======== LOOKING FOR CURL ========================")
 find_package(CURL REQUIRED)
-include_directories(${CURL_INCLUDE_DIRS})
 
 # ----------------------------------------------------------------------------------------
 message(STATUS "======== LOOKING FOR GOLANG ========================")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,11 +68,17 @@ add_custom_target(examples ALL COMMAND ${SCRIPTS_DIR}/build-examples.sh WORKING_
 # ----------------------------------------------------------------------------------------
 function(ADD_GO_INSTALLABLE_PROGRAM NAME MAIN_SRC DEST_DIR)
     get_filename_component(MAIN_SRC_ABS ${MAIN_SRC} ABSOLUTE)
+    file(GLOB SRC_FILE_LIST "*.go")
+    set(EXE_NAME ${NAME})
+    if (WIN32)
+        set(EXE_NAME ${NAME}.exe)
+    endif()
+
     add_custom_target(${NAME} ALL)
     add_custom_command(TARGET ${NAME}
                     COMMAND go build
-                    -o "${DEST_DIR}/${NAME}"
-                    ${CMAKE_GO_FLAGS} ${MAIN_SRC}
+                    -o "${DEST_DIR}/${EXE_NAME}"
+                    ${CMAKE_GO_FLAGS} ${SRC_FILE_LIST}
                     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
                     DEPENDS ${MAIN_SRC_ABS} ${MAIN_SRC})
 endfunction(ADD_GO_INSTALLABLE_PROGRAM)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,7 +67,7 @@ add_custom_target(examples ALL COMMAND ${SCRIPTS_DIR}/build-examples.sh WORKING_
 # ----------------------------------------------------------------------------------------
 function(ADD_GO_INSTALLABLE_PROGRAM NAME MAIN_SRC DEST_DIR)
     get_filename_component(MAIN_SRC_ABS ${MAIN_SRC} ABSOLUTE)
-    file(GLOB SRC_FILE_LIST "*.go")
+    file(GLOB SRC_FILE_LIST "${MAIN_SRC}/*.go")
     set(EXE_NAME ${NAME})
     if (WIN32)
         set(EXE_NAME ${NAME}.exe)
@@ -85,10 +85,10 @@ endfunction(ADD_GO_INSTALLABLE_PROGRAM)
 # ----------------------------------------------------------------------------------------
 add_subdirectory(other/install)
 
-ADD_GO_INSTALLABLE_PROGRAM(chifra ${CMAKE_SOURCE_DIR}/apps/chifra/*.go ${BIN_DIR})
-ADD_GO_INSTALLABLE_PROGRAM(goMaker ${CMAKE_SOURCE_DIR}/dev_tools/goMaker/*.go ${BIN_DIR})
-ADD_GO_INSTALLABLE_PROGRAM(testRunner ${CMAKE_SOURCE_DIR}/dev_tools/testRunner/*.go ${BIN_DIR})
-ADD_GO_INSTALLABLE_PROGRAM(sdkFuzzer ${CMAKE_SOURCE_DIR}/dev_tools/sdkFuzzer/*.go ${BIN_DIR})
+ADD_GO_INSTALLABLE_PROGRAM(chifra ${CMAKE_SOURCE_DIR}/apps/chifra ${BIN_DIR})
+ADD_GO_INSTALLABLE_PROGRAM(goMaker ${CMAKE_SOURCE_DIR}/dev_tools/goMaker ${BIN_DIR})
+ADD_GO_INSTALLABLE_PROGRAM(testRunner ${CMAKE_SOURCE_DIR}/dev_tools/testRunner ${BIN_DIR})
+ADD_GO_INSTALLABLE_PROGRAM(sdkFuzzer ${CMAKE_SOURCE_DIR}/dev_tools/sdkFuzzer ${BIN_DIR})
 
 add_dependencies(testRunner goMaker)
 add_dependencies(sdkFuzzer goMaker)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -87,14 +87,14 @@ add_subdirectory(other/install)
 
 ADD_GO_INSTALLABLE_PROGRAM(chifra ${CMAKE_SOURCE_DIR}/apps/chifra ${BIN_DIR})
 ADD_GO_INSTALLABLE_PROGRAM(goMaker ${CMAKE_SOURCE_DIR}/dev_tools/goMaker ${BIN_DIR})
-ADD_GO_INSTALLABLE_PROGRAM(testRunner ${CMAKE_SOURCE_DIR}/dev_tools/testRunner ${BIN_DIR})
 if (NOT WIN32)
+    ADD_GO_INSTALLABLE_PROGRAM(testRunner ${CMAKE_SOURCE_DIR}/dev_tools/testRunner ${BIN_DIR})
     ADD_GO_INSTALLABLE_PROGRAM(sdkFuzzer ${CMAKE_SOURCE_DIR}/dev_tools/sdkFuzzer ${BIN_DIR})
     add_dependencies(sdkFuzzer goMaker)
+    add_dependencies(testRunner goMaker)
+    add_dependencies(chifra testRunner)
 endif()
 
-add_dependencies(testRunner goMaker)
-add_dependencies(chifra testRunner)
 add_dependencies(examples chifra)
 
 file(GLOB CHIFRA_FOR_DOCKER_FILES "${CMAKE_SOURCE_DIR}/apps/chifra/*.go")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,13 +88,17 @@ add_subdirectory(other/install)
 ADD_GO_INSTALLABLE_PROGRAM(chifra ${CMAKE_SOURCE_DIR}/apps/chifra ${BIN_DIR})
 ADD_GO_INSTALLABLE_PROGRAM(goMaker ${CMAKE_SOURCE_DIR}/dev_tools/goMaker ${BIN_DIR})
 ADD_GO_INSTALLABLE_PROGRAM(testRunner ${CMAKE_SOURCE_DIR}/dev_tools/testRunner ${BIN_DIR})
-ADD_GO_INSTALLABLE_PROGRAM(sdkFuzzer ${CMAKE_SOURCE_DIR}/dev_tools/sdkFuzzer ${BIN_DIR})
+if (NOT WIN32)
+    ADD_GO_INSTALLABLE_PROGRAM(sdkFuzzer ${CMAKE_SOURCE_DIR}/dev_tools/sdkFuzzer ${BIN_DIR})
+    add_dependencies(sdkFuzzer goMaker)
+endif()
 
 add_dependencies(testRunner goMaker)
-add_dependencies(sdkFuzzer goMaker)
 add_dependencies(chifra testRunner)
 add_dependencies(examples chifra)
+
+file(GLOB CHIFRA_FOR_DOCKER_FILES "${CMAKE_SOURCE_DIR}/apps/chifra/*.go")
 add_custom_target(chifra-for-docker ALL
-    COMMAND ${GO_EXECUTABLE} build -o ${BIN_DIR}/chifra ${CMAKE_SOURCE_DIR}/apps/chifra/*.go
+    COMMAND ${GO_EXECUTABLE} build -o ${BIN_DIR}/chifra ${CHIFRA_FOR_DOCKER_FILES}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/apps/chifra
-    DEPENDS ${CMAKE_SOURCE_DIR}/apps/chifra/*.go)
+    DEPENDS ${CHIFRA_FOR_DOCKER_FILES})

--- a/src/apps/chifra/cmd/root_initialize.go
+++ b/src/apps/chifra/cmd/root_initialize.go
@@ -67,7 +67,7 @@ func VerifyMigrations() {
 	}
 
 	// ...and the config file better exist.
-	configFile := filepath.Join(configFolder + "trueBlocks.toml")
+	configFile := filepath.Join(configFolder, "trueBlocks.toml")
 	if _, err := os.Stat(configFile); err != nil {
 		msg := strings.Replace(doesNotExist, "{0}", "{"+configFile+"}", -1)
 		msg = colors.ColoredWith(msg, colors.Yellow)

--- a/src/apps/chifra/cmd/root_initialize.go
+++ b/src/apps/chifra/cmd/root_initialize.go
@@ -28,11 +28,7 @@ func Initialize() bool {
 // VerifyOs will panic if the operating system isn't cooperating
 func VerifyOs() {
 	userOs := runtime.GOOS
-	if userOs == "windows" {
-		logger.Fatal("Windows is not supported\n")
-	}
-
-	if userOs != "linux" && userOs != "darwin" {
+	if userOs != "linux" && userOs != "darwin" && userOs != "windows" {
 		logger.Fatal("Unsupported operating system: ", userOs, "\n")
 	}
 

--- a/src/apps/chifra/internal/abis/handle_decache.go
+++ b/src/apps/chifra/internal/abis/handle_decache.go
@@ -68,7 +68,7 @@ func (opts *AbisOptions) HandleDecache(rCtx *output.RenderCtx) error {
 		}
 	} else {
 		for _, addr := range opts.Addrs {
-			path := config.PathToCache(chain) + "abis" + string(os.PathSeparator) + addr + ".json"
+			path := filepath.Join(config.PathToCache(chain), "abis", addr + ".json")
 			if file.FileExists(path) {
 				if err := os.Remove(path); err != nil {
 					logger.Warn(colors.Red+"Could not remove abi for address", addr, ":", err, "."+colors.Off)

--- a/src/apps/chifra/internal/abis/handle_decache.go
+++ b/src/apps/chifra/internal/abis/handle_decache.go
@@ -68,7 +68,7 @@ func (opts *AbisOptions) HandleDecache(rCtx *output.RenderCtx) error {
 		}
 	} else {
 		for _, addr := range opts.Addrs {
-			path := config.PathToCache(chain) + "abis/" + addr + ".json"
+			path := config.PathToCache(chain) + "abis" + string(os.PathSeparator) + addr + ".json"
 			if file.FileExists(path) {
 				if err := os.Remove(path); err != nil {
 					logger.Warn(colors.Red+"Could not remove abi for address", addr, ":", err, "."+colors.Off)

--- a/src/apps/chifra/internal/abis/handle_find.go
+++ b/src/apps/chifra/internal/abis/handle_find.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"io"
 	"os"
+	"path/filepath"
 	"runtime"
 	"sort"
 	"strings"
@@ -66,7 +67,7 @@ func (opts *AbisOptions) HandleFind(rCtx *output.RenderCtx) error {
 		defer checkOne.Release()
 
 		// TODO: UnchainedIndex --> This could be part of unchained index
-		sigsFile, err := os.OpenFile(config.PathToRootConfig()+"abis/known-000/uniq_sigs.tab", os.O_RDONLY, 0)
+		sigsFile, err := os.OpenFile(filepath.Join(config.PathToRootConfig(), "abis/known-000/uniq_sigs.tab"), os.O_RDONLY, 0)
 		if err != nil {
 			errorChan <- err
 			rCtx.Cancel()
@@ -80,7 +81,7 @@ func (opts *AbisOptions) HandleFind(rCtx *output.RenderCtx) error {
 		sigsScanner.Split(bufio.ScanLines)
 
 		// TODO: UnchainedIndex --> This could be part of unchained index
-		funcsFile, _ := os.OpenFile(config.PathToRootConfig()+"abis/known-000/uniq_funcs.tab", os.O_RDONLY, 0)
+		funcsFile, _ := os.OpenFile(filepath.Join(config.PathToRootConfig(), "abis/known-000/uniq_funcs.tab"), os.O_RDONLY, 0)
 		defer func() {
 			funcsFile.Close()
 		}()

--- a/src/apps/chifra/internal/abis/handle_list.go
+++ b/src/apps/chifra/internal/abis/handle_list.go
@@ -61,7 +61,7 @@ func (opts *AbisOptions) HandleList(rCtx *output.RenderCtx) error {
 			}
 			if testMode {
 				abi.LastModDate = "--date--"
-				abi.Path = strings.ReplaceAll(abi.Path, config.PathToRootConfig(), "./")
+				abi.Path = strings.ReplaceAll(abi.Path, config.PathToRootConfig(), "." + string(os.PathSeparator))
 			}
 			modelChan <- &abi
 		}

--- a/src/apps/chifra/internal/abis/handle_list.go
+++ b/src/apps/chifra/internal/abis/handle_list.go
@@ -61,7 +61,7 @@ func (opts *AbisOptions) HandleList(rCtx *output.RenderCtx) error {
 			}
 			if testMode {
 				abi.LastModDate = "--date--"
-				abi.Path = strings.ReplaceAll(abi.Path, config.PathToRootConfig(), "." + string(os.PathSeparator))
+				abi.Path = filepath.Clean(strings.ReplaceAll(abi.Path, config.PathToRootConfig(), "./"))
 			}
 			modelChan <- &abi
 		}

--- a/src/apps/chifra/internal/chunks/handle_check.go
+++ b/src/apps/chifra/internal/chunks/handle_check.go
@@ -7,6 +7,7 @@ package chunksPkg
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"sort"
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/base"
@@ -83,7 +84,7 @@ func (opts *ChunksOptions) check(rCtx *output.RenderCtx, blockNums []base.Blknum
 	if err != nil {
 		return err, false
 	}
-	historyFile := config.PathToRootConfig() + "unchained.txt"
+	historyFile := filepath.Join(config.PathToRootConfig(), "unchained.txt")
 	saved := history.FromHistory(historyFile, "headerVersion")
 	defer func() {
 		_ = history.ToHistory(historyFile, "headerVersion", saved)

--- a/src/apps/chifra/internal/chunks/handle_diff.go
+++ b/src/apps/chifra/internal/chunks/handle_diff.go
@@ -75,7 +75,7 @@ func (opts *ChunksOptions) handleDiff(chain, path string) (bool, error) {
 }
 
 func writeArray(disp, dest, fn string, lines []string) error {
-	outputFolder, _ := filepath.Abs("./" + dest)
+	outputFolder, _ := filepath.Abs("." + string(os.PathSeparator) + dest)
 	if !file.FolderExists(outputFolder) {
 		if err := os.MkdirAll(outputFolder, os.ModePerm); err != nil {
 			return err
@@ -218,8 +218,8 @@ func (opts *ChunksOptions) getParams(chain, path string) (string, string, base.R
 
 func toDiffPath(chain string, middleMark base.Blknum) string {
 	diffPath := os.Getenv("TB_CHUNKS_DIFFPATH")
-	if !strings.Contains(diffPath, "unchained/") {
-		diffPath = filepath.Join(diffPath, "unchained/", chain, "finalized")
+	if !strings.Contains(diffPath, "unchained" + string(os.PathSeparator)) {
+		diffPath = filepath.Join(diffPath, "unchained" + string(os.PathSeparator), chain, "finalized")
 	}
 	diffPath, _ = filepath.Abs(diffPath)
 	diffPath, _ = findFileByBlockNumber(chain, diffPath, middleMark)

--- a/src/apps/chifra/internal/chunks/handle_diff.go
+++ b/src/apps/chifra/internal/chunks/handle_diff.go
@@ -4,9 +4,9 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"sort"
-	"os"
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/base"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/colors"

--- a/src/apps/chifra/internal/chunks/handle_diff.go
+++ b/src/apps/chifra/internal/chunks/handle_diff.go
@@ -219,7 +219,7 @@ func (opts *ChunksOptions) getParams(chain, path string) (string, string, base.R
 func toDiffPath(chain string, middleMark base.Blknum) string {
 	diffPath := os.Getenv("TB_CHUNKS_DIFFPATH")
 	if !strings.Contains(diffPath, "unchained" + string(os.PathSeparator)) {
-		diffPath = filepath.Join(diffPath, "unchained" + string(os.PathSeparator), chain, "finalized")
+		diffPath = filepath.Join(diffPath, "unchained", chain, "finalized")
 	}
 	diffPath, _ = filepath.Abs(diffPath)
 	diffPath, _ = findFileByBlockNumber(chain, diffPath, middleMark)

--- a/src/apps/chifra/internal/chunks/handle_diff.go
+++ b/src/apps/chifra/internal/chunks/handle_diff.go
@@ -4,10 +4,9 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"sort"
-	"strings"
+	"os"
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/base"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/colors"
@@ -75,7 +74,7 @@ func (opts *ChunksOptions) handleDiff(chain, path string) (bool, error) {
 }
 
 func writeArray(disp, dest, fn string, lines []string) error {
-	outputFolder, _ := filepath.Abs("." + string(os.PathSeparator) + dest)
+	outputFolder, _ := filepath.Abs("./" + dest)
 	if !file.FolderExists(outputFolder) {
 		if err := os.MkdirAll(outputFolder, os.ModePerm); err != nil {
 			return err
@@ -218,7 +217,7 @@ func (opts *ChunksOptions) getParams(chain, path string) (string, string, base.R
 
 func toDiffPath(chain string, middleMark base.Blknum) string {
 	diffPath := os.Getenv("TB_CHUNKS_DIFFPATH")
-	if !strings.Contains(diffPath, "unchained" + string(os.PathSeparator)) {
+	if filepath.Base(diffPath) != "unchained" {
 		diffPath = filepath.Join(diffPath, "unchained", chain, "finalized")
 	}
 	diffPath, _ = filepath.Abs(diffPath)

--- a/src/apps/chifra/internal/init/handle_dryrun.go
+++ b/src/apps/chifra/internal/init/handle_dryrun.go
@@ -3,6 +3,7 @@ package initPkg
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/base"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/config"
@@ -19,7 +20,7 @@ func (opts *InitOptions) HandleDryRun(rCtx *output.RenderCtx) error {
 	if err != nil {
 		return err
 	}
-	historyFile := config.PathToRootConfig() + "unchained.txt"
+	historyFile := filepath.Join(config.PathToRootConfig(), "unchained.txt")
 	saved := history.FromHistory(historyFile, "headerVersion")
 	defer func() {
 		_ = history.ToHistory(historyFile, "headerVersion", saved)

--- a/src/apps/chifra/internal/init/handle_init_prepare.go
+++ b/src/apps/chifra/internal/init/handle_init_prepare.go
@@ -209,7 +209,7 @@ func (opts *InitOptions) reportReason(prefix string, status InitReason, path str
 		col := colors.BrightMagenta
 		if status == FILE_ERROR || status == NOT_IN_MANIFEST {
 			col = colors.BrightRed
-		} else if strings.Contains(path, "/blooms/") {
+		} else if strings.Contains(path, string(os.PathSeparator) + "blooms" + string(os.PathSeparator)) {
 			col = colors.BrightYellow
 		}
 		rng := base.RangeFromFilename(path)

--- a/src/apps/chifra/internal/monitors/handle_watch.go
+++ b/src/apps/chifra/internal/monitors/handle_watch.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"os"
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/base"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/colors"
@@ -43,7 +42,7 @@ func (opts *MonitorsOptions) RunMonitorScraper(wg *sync.WaitGroup, s *Scraper) {
 	defer wg.Done()
 
 	chain := opts.Globals.Chain
-	tmpPath := filepath.Join(config.PathToCache(chain), "tmp") + string(os.PathSeparator)
+	tmpPath := filepath.Join(config.PathToCache(chain), "tmp")
 
 	s.ChangeState(true, tmpPath)
 

--- a/src/apps/chifra/internal/monitors/handle_watch.go
+++ b/src/apps/chifra/internal/monitors/handle_watch.go
@@ -43,7 +43,7 @@ func (opts *MonitorsOptions) RunMonitorScraper(wg *sync.WaitGroup, s *Scraper) {
 	defer wg.Done()
 
 	chain := opts.Globals.Chain
-	tmpPath := config.PathToCache(chain) + "tmp" + string(os.PathSeparator)
+	tmpPath := filepath.Join(config.PathToCache(chain), "tmp") + string(os.PathSeparator)
 
 	s.ChangeState(true, tmpPath)
 

--- a/src/apps/chifra/internal/monitors/handle_watch.go
+++ b/src/apps/chifra/internal/monitors/handle_watch.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"os"
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/base"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/colors"
@@ -42,7 +43,7 @@ func (opts *MonitorsOptions) RunMonitorScraper(wg *sync.WaitGroup, s *Scraper) {
 	defer wg.Done()
 
 	chain := opts.Globals.Chain
-	tmpPath := config.PathToCache(chain) + "tmp/"
+	tmpPath := config.PathToCache(chain) + "tmp" + string(os.PathSeparator)
 
 	s.ChangeState(true, tmpPath)
 

--- a/src/apps/chifra/internal/scrape/scrape_blaze.go
+++ b/src/apps/chifra/internal/scrape/scrape_blaze.go
@@ -161,8 +161,8 @@ var writeMutex sync.Mutex
 
 // WriteAppearances writes the appearance for a chunk to a file
 func (bm *BlazeManager) WriteAppearances(bn base.Blknum, addrMap uniq.AddressBooleanMap) (err error) {
-	ripePath := config.PathToIndex(bm.chain) + "ripe/"
-	unripePath := config.PathToIndex(bm.chain) + "unripe/"
+	ripePath := config.PathToIndex(bm.chain) + "ripe" + string(os.PathSeparator)
+	unripePath := config.PathToIndex(bm.chain) + "unripe" + string(os.PathSeparator)
 	appendScrapeError := func(err error) {
 		bm.errors = append(bm.errors, scrapeError{block: bn, err: err})
 	}

--- a/src/apps/chifra/internal/scrape/scrape_blaze.go
+++ b/src/apps/chifra/internal/scrape/scrape_blaze.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -161,8 +162,8 @@ var writeMutex sync.Mutex
 
 // WriteAppearances writes the appearance for a chunk to a file
 func (bm *BlazeManager) WriteAppearances(bn base.Blknum, addrMap uniq.AddressBooleanMap) (err error) {
-	ripePath := config.PathToIndex(bm.chain) + "ripe" + string(os.PathSeparator)
-	unripePath := config.PathToIndex(bm.chain) + "unripe" + string(os.PathSeparator)
+	ripePath := filepath.Join(config.PathToIndex(bm.chain), "ripe")
+	unripePath := filepath.Join(config.PathToIndex(bm.chain), "unripe")
 	appendScrapeError := func(err error) {
 		bm.errors = append(bm.errors, scrapeError{block: bn, err: err})
 	}

--- a/src/apps/chifra/internal/scrape/scrape_consolidate.go
+++ b/src/apps/chifra/internal/scrape/scrape_consolidate.go
@@ -96,7 +96,7 @@ func (bm *BlazeManager) Consolidate(ctx context.Context, blocks []base.Blknum) e
 		isOvertop := nAppearances >= int(bm.PerChunk()) // Does this block overtop a chunk?
 		if isSnap || isOvertop {
 			// Make a chunk - i.e., consolidate
-			chunkPath := indexPath + "finalized" + string(os.PathSeparator) + chunkRange.String() + ".bin"
+			chunkPath := filepath.Join(indexPath, "finalized", chunkRange.String() + ".bin")
 			publisher := base.ZeroAddr
 			var chunk index.Chunk
 			if report, err := chunk.Write(chain, publisher, chunkPath, appMap, nAppearances); err != nil {

--- a/src/apps/chifra/internal/scrape/scrape_consolidate.go
+++ b/src/apps/chifra/internal/scrape/scrape_consolidate.go
@@ -96,7 +96,7 @@ func (bm *BlazeManager) Consolidate(ctx context.Context, blocks []base.Blknum) e
 		isOvertop := nAppearances >= int(bm.PerChunk()) // Does this block overtop a chunk?
 		if isSnap || isOvertop {
 			// Make a chunk - i.e., consolidate
-			chunkPath := indexPath + "finalized/" + chunkRange.String() + ".bin"
+			chunkPath := indexPath + "finalized" + string(os.PathSeparator) + chunkRange.String() + ".bin"
 			publisher := base.ZeroAddr
 			var chunk index.Chunk
 			if report, err := chunk.Write(chain, publisher, chunkPath, appMap, nAppearances); err != nil {

--- a/src/apps/chifra/pkg/base/fileRange.go
+++ b/src/apps/chifra/pkg/base/fileRange.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"os"
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/config"
 )
@@ -68,7 +67,7 @@ func RangeFromFilenameE(path string) (blkRange FileRange, err error) {
 
 // RangeFromRangeString returns a file range from a string
 func RangeFromRangeString(rngStr string) FileRange {
-	return RangeFromFilename(config.PathToIndex("mainnet") + "finalized" + string(os.PathSeparator) + rngStr + ".bin") // okay to use mainnet since we're only interested in range
+	return RangeFromFilename(filepath.Join(config.PathToIndex("mainnet"), "finalized", rngStr + ".bin")) // okay to use mainnet since we're only interested in range
 }
 
 func (r FileRange) String() string {
@@ -77,7 +76,7 @@ func (r FileRange) String() string {
 
 // RangeToFilename returns a fileName and existence bool given a file range and a type
 func (r *FileRange) RangeToFilename(chain string) string {
-	return config.PathToIndex(chain) + "finalized" + string(os.PathSeparator) + r.String() + ".bin"
+	return filepath.Join(config.PathToIndex(chain), "finalized", r.String() + ".bin")
 }
 
 // Follows returns true if the range is strictly after the needle range.

--- a/src/apps/chifra/pkg/base/fileRange.go
+++ b/src/apps/chifra/pkg/base/fileRange.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"os"
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/config"
 )
@@ -67,7 +68,7 @@ func RangeFromFilenameE(path string) (blkRange FileRange, err error) {
 
 // RangeFromRangeString returns a file range from a string
 func RangeFromRangeString(rngStr string) FileRange {
-	return RangeFromFilename(config.PathToIndex("mainnet") + "finalized/" + rngStr + ".bin") // okay to use mainnet since we're only interested in range
+	return RangeFromFilename(config.PathToIndex("mainnet") + "finalized" + string(os.PathSeparator) + rngStr + ".bin") // okay to use mainnet since we're only interested in range
 }
 
 func (r FileRange) String() string {
@@ -76,7 +77,7 @@ func (r FileRange) String() string {
 
 // RangeToFilename returns a fileName and existence bool given a file range and a type
 func (r *FileRange) RangeToFilename(chain string) string {
-	return config.PathToIndex(chain) + "finalized/" + r.String() + ".bin"
+	return config.PathToIndex(chain) + "finalized" + string(os.PathSeparator) + r.String() + ".bin"
 }
 
 // Follows returns true if the range is strictly after the needle range.

--- a/src/apps/chifra/pkg/cache/store.go
+++ b/src/apps/chifra/pkg/cache/store.go
@@ -70,7 +70,7 @@ func (s *Store) resolvePath(value Locator) (resolved string, err error) {
 		err = errors.New("empty CacheLocations")
 		return
 	}
-	if strings.HasPrefix(directory, "/") {
+	if strings.HasPrefix(directory, string(os.PathSeparator)) {
 		resolved = path.Join(directory, (id + "." + extension))
 	} else {
 		resolved = path.Join(s.rootDir, directory, (id + "." + extension))

--- a/src/apps/chifra/pkg/config/config.go
+++ b/src/apps/chifra/pkg/config/config.go
@@ -43,9 +43,9 @@ type ConfigFile struct {
 // init sets up default values for the given configuration
 func init() {
 	// The location of the per chain caches
-	cachePath = filepath.Join(PathToRootConfig(), "cache") + string(os.PathSeparator)
+	cachePath = filepath.Join(PathToRootConfig(), "cache")
 	// The location of the per chain unchained indexes
-	indexPath = filepath.Join(PathToRootConfig(), "unchained") + string(os.PathSeparator)
+	indexPath = filepath.Join(PathToRootConfig(), "unchained")
 }
 
 var configMutex sync.Mutex
@@ -83,22 +83,22 @@ func GetRootConfig() *ConfigFile {
 
 	cachePath := trueBlocksConfig.Settings.CachePath
 	if len(cachePath) == 0 || cachePath == "<not_set>" {
-		cachePath = filepath.Join(configPath, "cache") + string(os.PathSeparator)
+		cachePath = filepath.Join(configPath, "cache")
 	}
 	cachePath = strings.Replace(cachePath, "$HOME", user.HomeDir, -1)
 	cachePath = strings.Replace(cachePath, "~", user.HomeDir, -1)
-	if !strings.Contains(cachePath, string(os.PathSeparator) + "cache") {
+	if filepath.Base(cachePath) != "cache" {
 		cachePath = filepath.Join(cachePath, "cache")
 	}
 	trueBlocksConfig.Settings.CachePath = cachePath
 
 	indexPath := trueBlocksConfig.Settings.IndexPath
 	if len(indexPath) == 0 || indexPath == "<not_set>" {
-		indexPath = filepath.Join(configPath, "unchained") + string(os.PathSeparator)
+		indexPath = filepath.Join(configPath, "unchained")
 	}
 	indexPath = strings.Replace(indexPath, "$HOME", user.HomeDir, -1)
 	indexPath = strings.Replace(indexPath, "~", user.HomeDir, -1)
-	if !strings.Contains(indexPath, string(os.PathSeparator) + "unchained") {
+	if filepath.Base(indexPath) != "unchained" {
 		indexPath = filepath.Join(indexPath, "unchained")
 	}
 	trueBlocksConfig.Settings.IndexPath = indexPath
@@ -185,7 +185,7 @@ func PathToRootConfig() string {
 	    osPath = "AppData/Local/trueblocks"
 	}
 
-	return filepath.Join(user.HomeDir, osPath) + string(os.PathSeparator)
+	return filepath.Join(user.HomeDir, filepath.Clean(osPath))
 }
 
 func pathFromXDG(envVar string) (string, error) {

--- a/src/apps/chifra/pkg/config/config.go
+++ b/src/apps/chifra/pkg/config/config.go
@@ -43,9 +43,9 @@ type ConfigFile struct {
 // init sets up default values for the given configuration
 func init() {
 	// The location of the per chain caches
-	cachePath = PathToRootConfig() + "cache/"
+	cachePath = PathToRootConfig() + "cache" + string(os.PathSeparator);
 	// The location of the per chain unchained indexes
-	indexPath = PathToRootConfig() + "unchained/"
+	indexPath = PathToRootConfig() + "unchained" + string(os.PathSeparator);
 }
 
 var configMutex sync.Mutex
@@ -185,7 +185,7 @@ func PathToRootConfig() string {
 	    osPath = "AppData/Local/trueblocks"
 	}
 
-	return filepath.Join(user.HomeDir, osPath) + "/"
+	return filepath.Join(user.HomeDir, osPath) + string(os.PathSeparator)
 }
 
 func pathFromXDG(envVar string) (string, error) {

--- a/src/apps/chifra/pkg/config/config.go
+++ b/src/apps/chifra/pkg/config/config.go
@@ -83,22 +83,22 @@ func GetRootConfig() *ConfigFile {
 
 	cachePath := trueBlocksConfig.Settings.CachePath
 	if len(cachePath) == 0 || cachePath == "<not_set>" {
-		cachePath = filepath.Join(configPath, "cache") + "/"
+		cachePath = filepath.Join(configPath, "cache") + string(os.PathSeparator)
 	}
 	cachePath = strings.Replace(cachePath, "$HOME", user.HomeDir, -1)
 	cachePath = strings.Replace(cachePath, "~", user.HomeDir, -1)
-	if !strings.Contains(cachePath, "/cache") {
+	if !strings.Contains(cachePath, string(os.PathSeparator) + "cache") {
 		cachePath = filepath.Join(cachePath, "cache")
 	}
 	trueBlocksConfig.Settings.CachePath = cachePath
 
 	indexPath := trueBlocksConfig.Settings.IndexPath
 	if len(indexPath) == 0 || indexPath == "<not_set>" {
-		indexPath = filepath.Join(configPath, "unchained") + "/"
+		indexPath = filepath.Join(configPath, "unchained") + string(os.PathSeparator)
 	}
 	indexPath = strings.Replace(indexPath, "$HOME", user.HomeDir, -1)
 	indexPath = strings.Replace(indexPath, "~", user.HomeDir, -1)
-	if !strings.Contains(indexPath, "/unchained") {
+	if !strings.Contains(indexPath, string(os.PathSeparator) + "unchained") {
 		indexPath = filepath.Join(indexPath, "unchained")
 	}
 	trueBlocksConfig.Settings.IndexPath = indexPath
@@ -181,6 +181,8 @@ func PathToRootConfig() string {
 	osPath := ".local/share/trueblocks"
 	if userOs == "darwin" {
 		osPath = "Library/Application Support/TrueBlocks"
+	} else if userOs == "windows" {
+	    osPath = "AppData/Local/trueblocks"
 	}
 
 	return filepath.Join(user.HomeDir, osPath) + "/"

--- a/src/apps/chifra/pkg/config/config.go
+++ b/src/apps/chifra/pkg/config/config.go
@@ -43,9 +43,9 @@ type ConfigFile struct {
 // init sets up default values for the given configuration
 func init() {
 	// The location of the per chain caches
-	cachePath = PathToRootConfig() + "cache" + string(os.PathSeparator);
+	cachePath = filepath.Join(PathToRootConfig(), "cache") + string(os.PathSeparator)
 	// The location of the per chain unchained indexes
-	indexPath = PathToRootConfig() + "unchained" + string(os.PathSeparator);
+	indexPath = filepath.Join(PathToRootConfig(), "unchained") + string(os.PathSeparator)
 }
 
 var configMutex sync.Mutex

--- a/src/apps/chifra/pkg/config/config.go
+++ b/src/apps/chifra/pkg/config/config.go
@@ -185,7 +185,7 @@ func PathToRootConfig() string {
 	    osPath = "AppData/Local/trueblocks"
 	}
 
-	return filepath.Join(user.HomeDir, filepath.Clean(osPath))
+	return filepath.Join(user.HomeDir, osPath)
 }
 
 func pathFromXDG(envVar string) (string, error) {

--- a/src/apps/chifra/pkg/config/paths.go
+++ b/src/apps/chifra/pkg/config/paths.go
@@ -7,7 +7,6 @@ package config
 import (
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/file"
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/logger"
@@ -28,7 +27,7 @@ func PathToChainConfig(chain string) (string, error) {
 	ret := PathToRootConfig()
 
 	// Our configuration files are always in ./config folder relative to top most folder
-	cfgFolder := filepath.Join(ret, "config", chain) + string(os.PathSeparator)
+	cfgFolder := filepath.Join(ret, "config", chain)
 	_, err := os.Stat(cfgFolder)
 	return cfgFolder, err
 }
@@ -54,7 +53,7 @@ func PathToIndex(chain string) string {
 	}
 
 	// Probably already true, but can't hurt to be sure
-	if !strings.Contains(indexPath, string(os.PathSeparator) + "unchained") {
+	if filepath.Base(indexPath) != "unchained" {
 		indexPath = filepath.Join(indexPath, "unchained")
 	}
 
@@ -64,7 +63,7 @@ func PathToIndex(chain string) string {
 	}
 
 	// We know what we want, create it if it doesn't exist and return it
-	newPath := filepath.Join(indexPath, chain) + string(os.PathSeparator)
+	newPath := filepath.Join(indexPath, chain)
 	EstablishIndexPaths(newPath)
 	return newPath
 }
@@ -80,7 +79,7 @@ func PathToCache(chain string) string {
 	}
 
 	// Probably already true, but can't hurt to be sure
-	if !strings.Contains(cachePath, string(os.PathSeparator) + "cache") {
+	if filepath.Base(cachePath) != "cache" {
 		cachePath = filepath.Join(cachePath, "cache")
 	}
 
@@ -90,7 +89,7 @@ func PathToCache(chain string) string {
 	}
 
 	// We know what we want, create it if it doesn't exist and return it
-	newPath := filepath.Join(cachePath, chain) + string(os.PathSeparator)
+	newPath := filepath.Join(cachePath, chain)
 	EstablishCachePaths(newPath)
 	return newPath
 }

--- a/src/apps/chifra/pkg/config/paths.go
+++ b/src/apps/chifra/pkg/config/paths.go
@@ -28,7 +28,7 @@ func PathToChainConfig(chain string) (string, error) {
 	ret := PathToRootConfig()
 
 	// Our configuration files are always in ./config folder relative to top most folder
-	cfgFolder := filepath.Join(ret, "config/", chain) + "/"
+	cfgFolder := filepath.Join(ret, "config", chain) + string(os.PathSeparator)
 	_, err := os.Stat(cfgFolder)
 	return cfgFolder, err
 }
@@ -100,7 +100,7 @@ func EstablishCachePaths(cachePath string) {
 	folders := []string{
 		"abis",
 		"monitors",
-		"monitors/staging",
+		filepath.Join("monitors", "staging"),
 		"names",
 		"tmp",
 		"v1",

--- a/src/apps/chifra/pkg/config/paths.go
+++ b/src/apps/chifra/pkg/config/paths.go
@@ -54,7 +54,7 @@ func PathToIndex(chain string) string {
 	}
 
 	// Probably already true, but can't hurt to be sure
-	if !strings.Contains(indexPath, "/unchained") {
+	if !strings.Contains(indexPath, string(os.PathSeparator) + "unchained") {
 		indexPath = filepath.Join(indexPath, "unchained")
 	}
 
@@ -64,7 +64,7 @@ func PathToIndex(chain string) string {
 	}
 
 	// We know what we want, create it if it doesn't exist and return it
-	newPath := filepath.Join(indexPath, chain) + "/"
+	newPath := filepath.Join(indexPath, chain) + string(os.PathSeparator)
 	EstablishIndexPaths(newPath)
 	return newPath
 }
@@ -80,7 +80,7 @@ func PathToCache(chain string) string {
 	}
 
 	// Probably already true, but can't hurt to be sure
-	if !strings.Contains(cachePath, "/cache") {
+	if !strings.Contains(cachePath, string(os.PathSeparator) + "cache") {
 		cachePath = filepath.Join(cachePath, "cache")
 	}
 
@@ -90,7 +90,7 @@ func PathToCache(chain string) string {
 	}
 
 	// We know what we want, create it if it doesn't exist and return it
-	newPath := filepath.Join(cachePath, chain) + "/"
+	newPath := filepath.Join(cachePath, chain) + string(os.PathSeparator)
 	EstablishCachePaths(newPath)
 	return newPath
 }

--- a/src/apps/chifra/pkg/config/unchainedGroup.go
+++ b/src/apps/chifra/pkg/config/unchainedGroup.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -58,7 +59,7 @@ var m sync.Mutex
 func ExpectedVersion() string {
 	if headerVersion == "" {
 		m.Lock()
-		historyFile := PathToRootConfig() + "unchained.txt"
+		historyFile := filepath.Join(PathToRootConfig(), "unchained.txt")
 		headerVersion = history.FromHistory(historyFile, "headerVersion")
 		if headerVersion == "" {
 			headerVersion = "trueblocks-core@v2.0.0-release"
@@ -70,7 +71,7 @@ func ExpectedVersion() string {
 
 func SetExpectedVersion(version string) {
 	m.Lock()
-	historyFile := PathToRootConfig() + "unchained.txt"
+	historyFile := filepath.Join(PathToRootConfig(), "unchained.txt")
 	_ = history.ToHistory(historyFile, "headerVersion", version)
 	headerVersion = version
 	m.Unlock()

--- a/src/apps/chifra/pkg/file/lock.go
+++ b/src/apps/chifra/pkg/file/lock.go
@@ -5,52 +5,13 @@
 package file
 
 import (
-	"errors"
-	"io"
 	"os"
-	"syscall"
 	"time"
+	"syscall"
+	"errors"
 )
 
 var maxSecondsLock = 3
-
-// Lock asks the OS to lock a file for the current process
-func Lock(file *os.File) error {
-	// Lock configuration. We want both read (F_RDLCK) and
-	// write (F_WRLCK) locks, and by Start to be interpreted
-	// as the start of the file (Whence set to SEEK_SET).
-	//
-	// More: https://man7.org/linux/man-pages/man2/fcntl.2.html
-	lockConfig := &syscall.Flock_t{
-		Type:   syscall.F_RDLCK | syscall.F_WRLCK,
-		Whence: int16(io.SeekStart),
-		Start:  0,
-		Len:    0,
-	}
-
-	return changeLock(file, lockConfig)
-}
-
-// Unlock removes OS-level file lock
-func Unlock(file *os.File) error {
-	lockConfig := &syscall.Flock_t{
-		Type:   syscall.F_UNLCK,
-		Whence: int16(io.SeekStart),
-		Start:  0,
-		Len:    0,
-	}
-
-	return changeLock(file, lockConfig)
-}
-
-// changeLock is a helper function that sends the syscall to either lock or
-// unlock a file
-func changeLock(file *os.File, lockConfig *syscall.Flock_t) error {
-	// We use fcntl lock, which locks a file to a specific process
-	//
-	// More: https://stackoverflow.com/questions/29611352/what-is-the-difference-between-locking-with-fcntl-and-flock
-	return syscall.FcntlFlock(file.Fd(), syscall.F_SETLK, lockConfig)
-}
 
 var DefaultOpenFlags = os.O_RDWR | os.O_CREATE
 var DefaultOpenFlagsAppend = os.O_RDWR | os.O_CREATE | os.O_APPEND

--- a/src/apps/chifra/pkg/file/lock_linux.go
+++ b/src/apps/chifra/pkg/file/lock_linux.go
@@ -5,7 +5,7 @@
 package file
 
 import (
-	"errors"
+	"io"
 	"os"
 	"syscall"
 )

--- a/src/apps/chifra/pkg/file/lock_linux.go
+++ b/src/apps/chifra/pkg/file/lock_linux.go
@@ -1,0 +1,50 @@
+// Copyright 2021 The TrueBlocks Authors. All rights reserved.
+// Use of this source code is governed by a license that can
+// be found in the LICENSE file.
+
+package file
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+
+// Lock asks the OS to lock a file for the current process
+func Lock(file *os.File) error {
+	// Lock configuration. We want both read (F_RDLCK) and
+	// write (F_WRLCK) locks, and by Start to be interpreted
+	// as the start of the file (Whence set to SEEK_SET).
+	//
+	// More: https://man7.org/linux/man-pages/man2/fcntl.2.html
+	lockConfig := &syscall.Flock_t{
+		Type:   syscall.F_RDLCK | syscall.F_WRLCK,
+		Whence: int16(io.SeekStart),
+		Start:  0,
+		Len:    0,
+	}
+
+	return changeLock(file, lockConfig)
+}
+
+// Unlock removes OS-level file lock
+func Unlock(file *os.File) error {
+	lockConfig := &syscall.Flock_t{
+		Type:   syscall.F_UNLCK,
+		Whence: int16(io.SeekStart),
+		Start:  0,
+		Len:    0,
+	}
+
+	return changeLock(file, lockConfig)
+}
+
+// changeLock is a helper function that sends the syscall to either lock or
+// unlock a file
+func changeLock(file *os.File, lockConfig *syscall.Flock_t) error {
+	// We use fcntl lock, which locks a file to a specific process
+	//
+	// More: https://stackoverflow.com/questions/29611352/what-is-the-difference-between-locking-with-fcntl-and-flock
+	return syscall.FcntlFlock(file.Fd(), syscall.F_SETLK, lockConfig)
+}

--- a/src/apps/chifra/pkg/file/lock_windows.go
+++ b/src/apps/chifra/pkg/file/lock_windows.go
@@ -1,0 +1,17 @@
+// Copyright 2021 The TrueBlocks Authors. All rights reserved.
+// Use of this source code is governed by a license that can
+// be found in the LICENSE file.
+
+package file
+
+import (
+	"os"
+)
+
+func Lock(file *os.File) error {
+	return nil
+}
+
+func Unlock(file *os.File) error {
+	return nil
+}

--- a/src/apps/chifra/pkg/index/download_chunks.go
+++ b/src/apps/chifra/pkg/index/download_chunks.go
@@ -113,7 +113,7 @@ func getDownloadWorker(chain string, workerArgs downloadWorkerArguments, chunkTy
 
 				if workerArgs.ctx.Err() != nil {
 					// User hit control + c - clean up both peices for the current chunk
-					chunkPath := config.PathToIndex(chain) + "finalized/" + chunk.Range + ".bin"
+					chunkPath := config.PathToIndex(chain) + "finalized" + string(os.PathSeparator) + chunk.Range + ".bin"
 					removeLocalFile(ToIndexPath(chunkPath), "user canceled", progressChannel)
 					removeLocalFile(ToBloomPath(chunkPath), "user canceled", progressChannel)
 					progressChannel <- &progress.ProgressMsg{
@@ -307,7 +307,7 @@ func DownloadChunks(chain string, chunksToDownload []types.ChunkRecord, chunkTyp
 
 // writeBytesToDisc save the downloaded bytes to disc
 func writeBytesToDisc(chain string, chunkType walk.CacheType, res *jobResult) error {
-	fullPath := config.PathToIndex(chain) + "finalized/" + res.rng + ".bin"
+	fullPath := config.PathToIndex(chain) + "finalized" + string(os.PathSeparator) + res.rng + ".bin"
 	if chunkType == walk.Index_Bloom {
 		fullPath = ToBloomPath(fullPath)
 	}

--- a/src/apps/chifra/pkg/index/download_chunks.go
+++ b/src/apps/chifra/pkg/index/download_chunks.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -153,7 +152,7 @@ type fetchResult struct {
 // fetchFromIpfsGateway downloads a chunk from an IPFS gateway using HTTP
 func fetchFromIpfsGateway(ctx context.Context, gateway, hash string) (*fetchResult, error) {
 	url, _ := url.Parse(gateway)
-	url.Path = filepath.Join(url.Path, hash)
+	url.Path += hash
 
 	debug.DebugCurlStr(url.String())
 	request, err := http.NewRequestWithContext(ctx, "GET", url.String(), nil)

--- a/src/apps/chifra/pkg/index/download_chunks.go
+++ b/src/apps/chifra/pkg/index/download_chunks.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -113,7 +114,7 @@ func getDownloadWorker(chain string, workerArgs downloadWorkerArguments, chunkTy
 
 				if workerArgs.ctx.Err() != nil {
 					// User hit control + c - clean up both peices for the current chunk
-					chunkPath := config.PathToIndex(chain) + "finalized" + string(os.PathSeparator) + chunk.Range + ".bin"
+					chunkPath := filepath.Join(config.PathToIndex(chain), "finalized", chunk.Range + ".bin")
 					removeLocalFile(ToIndexPath(chunkPath), "user canceled", progressChannel)
 					removeLocalFile(ToBloomPath(chunkPath), "user canceled", progressChannel)
 					progressChannel <- &progress.ProgressMsg{
@@ -307,7 +308,7 @@ func DownloadChunks(chain string, chunksToDownload []types.ChunkRecord, chunkTyp
 
 // writeBytesToDisc save the downloaded bytes to disc
 func writeBytesToDisc(chain string, chunkType walk.CacheType, res *jobResult) error {
-	fullPath := config.PathToIndex(chain) + "finalized" + string(os.PathSeparator) + res.rng + ".bin"
+	fullPath := filepath.Join(config.PathToIndex(chain), "finalized", res.rng + ".bin")
 	if chunkType == walk.Index_Bloom {
 		fullPath = ToBloomPath(fullPath)
 	}

--- a/src/apps/chifra/pkg/index/paths.go
+++ b/src/apps/chifra/pkg/index/paths.go
@@ -2,6 +2,13 @@ package index
 
 import (
 	"strings"
+	"os"
+)
+
+const (
+    blooms_str    = string(os.PathSeparator) + "blooms"    + string(os.PathSeparator)
+    staging_str   = string(os.PathSeparator) + "staging"   + string(os.PathSeparator)
+    finalized_str = string(os.PathSeparator) + "finalized" + string(os.PathSeparator)
 )
 
 func isCacheType(path string, folder, extension string) bool {
@@ -21,8 +28,8 @@ func ToBloomPath(pathIn string) string {
 	}
 	ret := strings.Replace(pathIn, ".bin", ".bloom", -1)
 	ret = strings.Replace(ret, ".txt", ".bloom", -1)
-	ret = strings.Replace(ret, "/finalized/", "/blooms/", -1)
-	ret = strings.Replace(ret, "/staging/", "/blooms/", -1)
+	ret = strings.Replace(ret, finalized_str, blooms_str, -1)
+	ret = strings.Replace(ret, staging_str, blooms_str, -1)
 	return ret
 }
 
@@ -34,8 +41,8 @@ func ToIndexPath(pathIn string) string {
 
 	ret := strings.Replace(pathIn, ".bloom", ".bin", -1)
 	ret = strings.Replace(ret, ".txt", ".bin", -1)
-	ret = strings.Replace(ret, "/blooms/", "/finalized/", -1)
-	ret = strings.Replace(ret, "/staging/", "/finalized/", -1)
+	ret = strings.Replace(ret, blooms_str, finalized_str, -1)
+	ret = strings.Replace(ret, staging_str, finalized_str, -1)
 	return ret
 }
 
@@ -47,7 +54,7 @@ func ToStagingPath(pathIn string) string {
 
 	ret := strings.Replace(pathIn, ".bin", ".txt", -1)
 	ret = strings.Replace(ret, ".bloom", ".txt", -1)
-	ret = strings.Replace(ret, "/finalized/", "/staging/", -1)
-	ret = strings.Replace(ret, "/blooms/", "/staging/", -1)
+	ret = strings.Replace(ret, finalized_str, staging_str, -1)
+	ret = strings.Replace(ret, blooms_str, staging_str, -1)
 	return ret
 }

--- a/src/apps/chifra/pkg/index/paths.go
+++ b/src/apps/chifra/pkg/index/paths.go
@@ -27,7 +27,7 @@ func ToBloomPath(pathIn string) string {
 	if isCacheType(pathIn, "blooms", "bloom") {
 		return pathIn
 	}
-	ret := strings.Replace(filepath.Clean(pathIn), ".bin", ".bloom", -1))
+	ret := strings.Replace(filepath.Clean(pathIn), ".bin", ".bloom", -1)
 	ret = strings.Replace(ret, ".txt", ".bloom", -1)
 	ret = strings.Replace(ret, finalized_str, blooms_str, -1)
 	ret = strings.Replace(ret, staging_str, blooms_str, -1)
@@ -40,7 +40,7 @@ func ToIndexPath(pathIn string) string {
 		return pathIn
 	}
 
-	ret := strings.Replace(filepath.Clean(pathIn), ".bloom", ".bin", -1))
+	ret := strings.Replace(filepath.Clean(pathIn), ".bloom", ".bin", -1)
 	ret = strings.Replace(ret, ".txt", ".bin", -1)
 	ret = strings.Replace(ret, blooms_str, finalized_str, -1)
 	ret = strings.Replace(ret, staging_str, finalized_str, -1)
@@ -53,7 +53,7 @@ func ToStagingPath(pathIn string) string {
 		return pathIn
 	}
 
-	ret := strings.Replace(filepath.Clean(pathIn), ".bin", ".txt", -1))
+	ret := strings.Replace(filepath.Clean(pathIn), ".bin", ".txt", -1)
 	ret = strings.Replace(ret, ".bloom", ".txt", -1)
 	ret = strings.Replace(ret, finalized_str, staging_str, -1)
 	ret = strings.Replace(ret, blooms_str, staging_str, -1)

--- a/src/apps/chifra/pkg/index/paths.go
+++ b/src/apps/chifra/pkg/index/paths.go
@@ -3,6 +3,7 @@ package index
 import (
 	"strings"
 	"os"
+	"path/filepath"
 )
 
 const (
@@ -26,7 +27,7 @@ func ToBloomPath(pathIn string) string {
 	if isCacheType(pathIn, "blooms", "bloom") {
 		return pathIn
 	}
-	ret := strings.Replace(pathIn, ".bin", ".bloom", -1)
+	ret := strings.Replace(filepath.Clean(pathIn), ".bin", ".bloom", -1))
 	ret = strings.Replace(ret, ".txt", ".bloom", -1)
 	ret = strings.Replace(ret, finalized_str, blooms_str, -1)
 	ret = strings.Replace(ret, staging_str, blooms_str, -1)
@@ -39,7 +40,7 @@ func ToIndexPath(pathIn string) string {
 		return pathIn
 	}
 
-	ret := strings.Replace(pathIn, ".bloom", ".bin", -1)
+	ret := strings.Replace(filepath.Clean(pathIn), ".bloom", ".bin", -1))
 	ret = strings.Replace(ret, ".txt", ".bin", -1)
 	ret = strings.Replace(ret, blooms_str, finalized_str, -1)
 	ret = strings.Replace(ret, staging_str, finalized_str, -1)
@@ -52,7 +53,7 @@ func ToStagingPath(pathIn string) string {
 		return pathIn
 	}
 
-	ret := strings.Replace(pathIn, ".bin", ".txt", -1)
+	ret := strings.Replace(filepath.Clean(pathIn), ".bin", ".txt", -1))
 	ret = strings.Replace(ret, ".bloom", ".txt", -1)
 	ret = strings.Replace(ret, finalized_str, staging_str, -1)
 	ret = strings.Replace(ret, blooms_str, staging_str, -1)

--- a/src/apps/chifra/pkg/manifest/download.go
+++ b/src/apps/chifra/pkg/manifest/download.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/abi"
@@ -69,7 +68,7 @@ func downloadManifest(chain, gatewayUrl, cid string) (*Manifest, error) {
 	if err != nil {
 		return nil, err
 	}
-	url.Path = filepath.Join(url.Path, cid)
+	url.Path += cid
 
 	debug.DebugCurlStr(url.String())
 	resp, err := http.Get(url.String())

--- a/src/apps/chifra/pkg/monitor/monitor.go
+++ b/src/apps/chifra/pkg/monitor/monitor.go
@@ -97,9 +97,9 @@ func (mon Monitor) String() string {
 // Path returns the path to the Monitor file
 func (mon *Monitor) Path() (path string) {
 	if mon.Staged {
-		path = config.PathToCache(mon.Chain) + "monitors" + string(os.PathSeparator) + "staging" + string(os.PathSeparator) + mon.Address.Hex() + Ext
+		path = filepath.Join(config.PathToCache(mon.Chain), "monitors", "staging", mon.Address.Hex() + Ext)
 	} else {
-		path = config.PathToCache(mon.Chain) + "monitors" + string(os.PathSeparator) + mon.Address.Hex() + Ext
+		path = filepath.Join(config.PathToCache(mon.Chain), "monitors", mon.Address.Hex() + Ext)
 	}
 	return
 }

--- a/src/apps/chifra/pkg/monitor/monitor.go
+++ b/src/apps/chifra/pkg/monitor/monitor.go
@@ -97,9 +97,9 @@ func (mon Monitor) String() string {
 // Path returns the path to the Monitor file
 func (mon *Monitor) Path() (path string) {
 	if mon.Staged {
-		path = config.PathToCache(mon.Chain) + "monitors/staging/" + mon.Address.Hex() + Ext
+		path = config.PathToCache(mon.Chain) + "monitors" + string(os.PathSeparator) + "staging" + string(os.PathSeparator) + mon.Address.Hex() + Ext
 	} else {
-		path = config.PathToCache(mon.Chain) + "monitors/" + mon.Address.Hex() + Ext
+		path = config.PathToCache(mon.Chain) + "monitors" + string(os.PathSeparator) + mon.Address.Hex() + Ext
 	}
 	return
 }

--- a/src/apps/chifra/pkg/monitor/monitor_freshen.go
+++ b/src/apps/chifra/pkg/monitor/monitor_freshen.go
@@ -128,7 +128,7 @@ func (updater *MonitorUpdate) FreshenMonitors(monitorArray *[]Monitor) (bool, er
 		return canceled, nil
 	}
 
-	bloomPath := filepath.Join(config.PathToIndex(updater.Chain), "blooms/")
+	bloomPath := filepath.Join(config.PathToIndex(updater.Chain), "blooms" + string(os.PathSeparator))
 	files, err := os.ReadDir(bloomPath)
 	if err != nil {
 		return canceled, err
@@ -144,7 +144,7 @@ func (updater *MonitorUpdate) FreshenMonitors(monitorArray *[]Monitor) (bool, er
 			continue
 		}
 		if !info.IsDir() {
-			fileName := bloomPath + "/" + info.Name()
+			fileName := bloomPath + string(os.PathSeparator) + info.Name()
 			if !walk.IsCacheType(fileName, walk.Index_Bloom, true /* checkExt */) {
 				continue // sometimes there are .gz files in this folder, for example
 			}

--- a/src/apps/chifra/pkg/monitor/monitor_freshen.go
+++ b/src/apps/chifra/pkg/monitor/monitor_freshen.go
@@ -128,7 +128,7 @@ func (updater *MonitorUpdate) FreshenMonitors(monitorArray *[]Monitor) (bool, er
 		return canceled, nil
 	}
 
-	bloomPath := filepath.Join(config.PathToIndex(updater.Chain), "blooms" + string(os.PathSeparator))
+	bloomPath := filepath.Join(config.PathToIndex(updater.Chain), "blooms")
 	files, err := os.ReadDir(bloomPath)
 	if err != nil {
 		return canceled, err
@@ -362,7 +362,7 @@ func needsMigration(addr string) error {
 	mon := Monitor{Address: base.HexToAddress(addr)}
 	path := strings.Replace(mon.Path(), ".mon.bin", ".acct.bin", -1)
 	if file.FileExists(path) {
-		path = strings.Replace(path, config.PathToCache(mon.Chain), "." + string(os.PathSeparator), -1)
+		path = filepath.Clean(strings.Replace(path, config.PathToCache(mon.Chain), "./", -1))
 		return validate.Usage("Old style monitor found at {0}. Please run '{1}'", path, "chifra config --migrate cache")
 	}
 	return nil

--- a/src/apps/chifra/pkg/monitor/monitor_freshen.go
+++ b/src/apps/chifra/pkg/monitor/monitor_freshen.go
@@ -362,7 +362,7 @@ func needsMigration(addr string) error {
 	mon := Monitor{Address: base.HexToAddress(addr)}
 	path := strings.Replace(mon.Path(), ".mon.bin", ".acct.bin", -1)
 	if file.FileExists(path) {
-		path = strings.Replace(path, config.PathToCache(mon.Chain), "./", -1)
+		path = strings.Replace(path, config.PathToCache(mon.Chain), "." + string(os.PathSeparator), -1)
 		return validate.Usage("Old style monitor found at {0}. Please run '{1}'", path, "chifra config --migrate cache")
 	}
 	return nil

--- a/src/apps/chifra/pkg/monitor/monitor_freshen.go
+++ b/src/apps/chifra/pkg/monitor/monitor_freshen.go
@@ -144,7 +144,7 @@ func (updater *MonitorUpdate) FreshenMonitors(monitorArray *[]Monitor) (bool, er
 			continue
 		}
 		if !info.IsDir() {
-			fileName := bloomPath + string(os.PathSeparator) + info.Name()
+			fileName := filepath.Join(bloomPath, info.Name())
 			if !walk.IsCacheType(fileName, walk.Index_Bloom, true /* checkExt */) {
 				continue // sometimes there are .gz files in this folder, for example
 			}

--- a/src/apps/chifra/pkg/progress/scanbar.go
+++ b/src/apps/chifra/pkg/progress/scanbar.go
@@ -8,10 +8,6 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"syscall"
-	"unsafe"
-
-	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/base"
 )
 
 type ScanBar struct {
@@ -68,19 +64,4 @@ type winsize struct {
 	Col    uint16
 	Xpixel uint16
 	Ypixel uint16
-}
-
-func screenWidth() uint {
-	ws := &winsize{}
-	retCode, _, _ := syscall.Syscall(syscall.SYS_IOCTL,
-		uintptr(syscall.Stdin),
-		uintptr(syscall.TIOCGWINSZ),
-		uintptr(unsafe.Pointer(ws)))
-
-	if int(retCode) == -1 {
-		// This is okay if we're debugging in VSCode for example
-		// logger.Error("System call to syscall.SYS_IOCTL returned: ", errno)
-		return 120 // default reasonably
-	}
-	return uint(ws.Col)
 }

--- a/src/apps/chifra/pkg/progress/scanbar.go
+++ b/src/apps/chifra/pkg/progress/scanbar.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/base"
 )
 
 type ScanBar struct {

--- a/src/apps/chifra/pkg/progress/scanbar_linux.go
+++ b/src/apps/chifra/pkg/progress/scanbar_linux.go
@@ -1,0 +1,28 @@
+// Copyright 2021 The TrueBlocks Authors. All rights reserved.
+// Use of this source code is governed by a license that can
+// be found in the LICENSE file.
+
+package progress
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"syscall"
+	"unsafe"
+)
+
+func screenWidth() uint {
+	ws := &winsize{}
+	retCode, _, _ := syscall.Syscall(syscall.SYS_IOCTL,
+		uintptr(syscall.Stdin),
+		uintptr(syscall.TIOCGWINSZ),
+		uintptr(unsafe.Pointer(ws)))
+
+	if int(retCode) == -1 {
+		// This is okay if we're debugging in VSCode for example
+		// logger.Error("System call to syscall.SYS_IOCTL returned: ", errno)
+		return 120 // default reasonably
+	}
+	return uint(ws.Col)
+}

--- a/src/apps/chifra/pkg/progress/scanbar_linux.go
+++ b/src/apps/chifra/pkg/progress/scanbar_linux.go
@@ -5,9 +5,6 @@
 package progress
 
 import (
-	"fmt"
-	"io"
-	"strings"
 	"syscall"
 	"unsafe"
 )

--- a/src/apps/chifra/pkg/progress/scanbar_windows.go
+++ b/src/apps/chifra/pkg/progress/scanbar_windows.go
@@ -1,0 +1,9 @@
+// Copyright 2021 The TrueBlocks Authors. All rights reserved.
+// Use of this source code is governed by a license that can
+// be found in the LICENSE file.
+
+package progress
+
+func screenWidth() uint {
+	return 120 // default reasonably
+}

--- a/src/apps/chifra/pkg/tslib/establish.go
+++ b/src/apps/chifra/pkg/tslib/establish.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/TrueBlocks/trueblocks-core/src/apps/chifra/pkg/base"
@@ -54,7 +53,7 @@ func downloadTimestamps(chain, database, outputFn, cid string) (error, bool) {
 	if err != nil {
 		return err, false
 	}
-	url.Path = filepath.Join(url.Path, cid)
+	url.Path += cid
 
 	debug.DebugCurlStr(url.String())
 

--- a/src/apps/chifra/pkg/walk/walk.go
+++ b/src/apps/chifra/pkg/walk/walk.go
@@ -154,7 +154,7 @@ func GetRootPathFromCacheType(chain string, cacheType CacheType) string {
 	case Cache_Names:
 		fallthrough
 	case Cache_Tmp:
-		return filepath.Join(config.PathToCache(chain), CacheTypeToFolder[cacheType]) + "/"
+		return filepath.Join(config.PathToCache(chain), CacheTypeToFolder[cacheType]) + string(os.PathSeparator)
 
 	case Cache_Blocks:
 		fallthrough
@@ -177,7 +177,7 @@ func GetRootPathFromCacheType(chain string, cacheType CacheType) string {
 	case Cache_Transactions:
 		fallthrough
 	case Cache_Withdrawals:
-		return filepath.Join(config.PathToCache(chain), "v1", CacheTypeToFolder[cacheType]) + "/"
+		return filepath.Join(config.PathToCache(chain), "v1", CacheTypeToFolder[cacheType]) + string(os.PathSeparator)
 
 	case Index_Bloom:
 		fallthrough
@@ -190,7 +190,7 @@ func GetRootPathFromCacheType(chain string, cacheType CacheType) string {
 	case Index_Unripe:
 		fallthrough
 	case Index_Maps:
-		return filepath.Join(config.PathToIndex(chain), CacheTypeToFolder[cacheType]) + "/"
+		return filepath.Join(config.PathToIndex(chain), CacheTypeToFolder[cacheType]) + string(os.PathSeparator)
 	case Config:
 		return config.PathToRootConfig()
 	case Cache_NotACache:

--- a/src/apps/chifra/pkg/walk/walk.go
+++ b/src/apps/chifra/pkg/walk/walk.go
@@ -154,7 +154,7 @@ func GetRootPathFromCacheType(chain string, cacheType CacheType) string {
 	case Cache_Names:
 		fallthrough
 	case Cache_Tmp:
-		return filepath.Join(config.PathToCache(chain), CacheTypeToFolder[cacheType]) + string(os.PathSeparator)
+		return filepath.Join(config.PathToCache(chain), CacheTypeToFolder[cacheType])
 
 	case Cache_Blocks:
 		fallthrough
@@ -177,7 +177,7 @@ func GetRootPathFromCacheType(chain string, cacheType CacheType) string {
 	case Cache_Transactions:
 		fallthrough
 	case Cache_Withdrawals:
-		return filepath.Join(config.PathToCache(chain), "v1", CacheTypeToFolder[cacheType]) + string(os.PathSeparator)
+		return filepath.Join(config.PathToCache(chain), "v1", CacheTypeToFolder[cacheType])
 
 	case Index_Bloom:
 		fallthrough
@@ -190,7 +190,7 @@ func GetRootPathFromCacheType(chain string, cacheType CacheType) string {
 	case Index_Unripe:
 		fallthrough
 	case Index_Maps:
-		return filepath.Join(config.PathToIndex(chain), CacheTypeToFolder[cacheType]) + string(os.PathSeparator)
+		return filepath.Join(config.PathToIndex(chain), CacheTypeToFolder[cacheType])
 	case Config:
 		return config.PathToRootConfig()
 	case Cache_NotACache:
@@ -347,8 +347,8 @@ func GetCacheItem(chain string, testMode bool, cT CacheType, cacheInfo *CacheFil
 	}
 
 	display := cacheInfo.Path
-	display = strings.Replace(display, config.PathToCache(chain), "." + string(os.PathSeparator), -1)
-	display = strings.Replace(display, config.PathToIndex(chain), "." + string(os.PathSeparator), -1)
+	display = filepath.Clean(strings.Replace(display, config.PathToCache(chain), "./", -1))
+	display = filepath.Clean(strings.Replace(display, config.PathToIndex(chain), "./", -1))
 
 	switch cT {
 	case Index_Maps:

--- a/src/apps/chifra/pkg/walk/walk.go
+++ b/src/apps/chifra/pkg/walk/walk.go
@@ -347,8 +347,8 @@ func GetCacheItem(chain string, testMode bool, cT CacheType, cacheInfo *CacheFil
 	}
 
 	display := cacheInfo.Path
-	display = strings.Replace(display, config.PathToCache(chain), "./", -1)
-	display = strings.Replace(display, config.PathToIndex(chain), "./", -1)
+	display = strings.Replace(display, config.PathToCache(chain), "." + string(os.PathSeparator), -1)
+	display = strings.Replace(display, config.PathToIndex(chain), "." + string(os.PathSeparator), -1)
 
 	switch cT {
 	case Index_Maps:

--- a/src/other/four_bytes/pkg/fourBytes/generate.go
+++ b/src/other/four_bytes/pkg/fourBytes/generate.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
+	"path/filepath"
 	"runtime"
 	"sync"
 
@@ -93,15 +93,15 @@ func writeWorker(i interface{}) {
 // GenerateFromFiles reads input files and creates four bytes database. It then sends it to writeWorkers to save
 // chunk files.
 func GenerateFromFiles(outDir string) (err error) {
-	sigsFile, err := os.OpenFile(path.Join(config.PathToRootConfig(), "abis/known-000/uniq_sigs.tab"), os.O_RDONLY, 0)
+	sigsFile, err := os.OpenFile(filepath.Join(config.PathToRootConfig(), "abis/known-000/uniq_sigs.tab"), os.O_RDONLY, 0)
 	if err != nil {
 		return
 	}
-	funcsFile, err := os.OpenFile(path.Join(config.PathToRootConfig(), "abis/known-000/uniq_funcs.tab"), os.O_RDONLY, 0)
+	funcsFile, err := os.OpenFile(filepath.Join(config.PathToRootConfig(), "abis/known-000/uniq_funcs.tab"), os.O_RDONLY, 0)
 	if err != nil {
 		return
 	}
-	eventsFile, err := os.OpenFile(path.Join(config.PathToRootConfig(), "abis/known-000/uniq_events.tab"), os.O_RDONLY, 0)
+	eventsFile, err := os.OpenFile(filepath.Join(config.PathToRootConfig(), "abis/known-000/uniq_events.tab"), os.O_RDONLY, 0)
 	if err != nil {
 		return
 	}

--- a/src/other/install/init_configs.cmake
+++ b/src/other/install/init_configs.cmake
@@ -54,7 +54,7 @@ set(INSTALL_DEST "$ENV{XDG_CONFIG_HOME}")
 
 if("${INSTALL_DEST}" STREQUAL "")
 	if(WIN32)
-		PrintLine("Windows build is not supported")
+		set(INSTALL_DEST "$ENV{LOCALAPPDATA}/trueblocks")
 	elseif(APPLE)
 		set(INSTALL_DEST "$ENV{HOME}/Library/Application Support/TrueBlocks")
 	else()


### PR DESCRIPTION
To preface this all, I'm not a Go programmer by any means so I may have made changes that are not idiomatic or familiar, but I've managed what I could.

Initial windows support for Chifra, not too many changes were required due to Go's standard library being inherently quite cross-platform friendly. 

The largest change is using platform-dependent directory separators `os.PathSeparator`, whilst Windows actually does support `/` separators in all its APIs, Go generates `\` separators and the codebase typically checks for `/` separators which causes all sorts of checks to fail.

I haven't used all of Chifra's features to be sure that it works across the board but basic operations like looking up blocks and exporting wallet appearances appears to be working.

Build and run instructions are very similar to the current build instructions for Unix platforms. For example you'll generally need all the pre-requisites as stated in the current installation steps, (go, python, ...) on your path. CURL will need to be built manually, I recommend this to be done via CMake because we use `target_link_libraries` to link CURL to trueblocks. Here's an example invocation of that:

```bash
# Navigate to root of CURL repository
cmake -B Build -S . -G Ninja -D BUILD_SHARED_LIBS=OFF -D BUILD_STATIC_LIBS=ON -D BUILD_STATIC_CURL=ON -D CURL_DISABLE_INSTALL=ON -D CURL_STATIC_CRT=ON -D ENABLE_UNICODE=ON -D CMAKE_BUILD_TYPE=Release
cmake --build Build --parallel --verbose
cmake --install Build --prefix Build/Install
```

Then trueblocks can be built by pointing CMake to the CURL build:

```bash
# Navigate to root of trueblocks-core repository
cmake -B Build -S src -G Ninja -D CMAKE_PREFIX_PATH=<path/to/Curl>/Build/Install
cmake --build Build --parallel --verbose
```

The binaries are dropped into `<path/to>/trueblocks-core/bin` as per Unix instructions. The configuration files are installed to `%LOCALAPPDATA%/trueblocks` which is the standard Window's data directory for user files.

```
> build\chifra.exe config --paths
type    path
configPath      C:\Users\<name>\AppData\Local\trueblocks\
cachePath       C:\Users\<name>\AppData\Local\trueblocks\cache\mainnet\
indexPath       C:\Users\<name>\AppData\Local\trueblocks\unchained\mainnet\
```

Testing the install as per instructions

```
> build\chifra.exe blocks 12
{
  "data": [
    {
      "baseFeePerGas": 0,
      "blockNumber": 12,
      "date": "2015-07-30 15:29:04 UTC",
      "difficulty": 17179844608,
      "gasLimit": 5000,
      "gasUsed": 0,
      "hash": "0xc63f666315fa1eae17e354fab532aeeecf549be93e358737d0648f50d57083a0",
      "miner": "0x0193d941b50d91be6567c7ee1c0fe7af498b4137",
      "parentHash": "0x3f5e756c3efcb93099361b7ddd0dabfeaa592439437c1c836e443ccb81e93242",
      "timestamp": 1438270144,
      "transactions": [],
      "uncles": [],
      "withdrawals": []
    }
  ]
}
```