### PR TITLE
Specify correct repo and path for "Edit this page" link on docs

### DIFF
--- a/docs/config/_default/params.toml
+++ b/docs/config/_default/params.toml
@@ -36,7 +36,8 @@ quality = 85
 footer = "Powered by <a href=\"https://gohugo.io/\">Hugo</a>"
 
 # Edit Page
-docsRepo = "https://github.com/TrueBlocks/trueblocks-docs"
+docsRepo = "https://github.com/TrueBlocks/trueblocks-core"
+docsRepoSubPath = "docs"
 editPage = true
 
 [options]


### PR DESCRIPTION
## Description

I noticed the "Edit this page" link was broken on the docs site and did a bit of investigation to figure out the fix.

Assuming I'm correct and the docs site uses doks-child-theme, [this example `params.toml` file](https://github.com/h-enk/doks-child-theme/blob/master/config/_default/params.toml) suggests the use of the parameter I've added in this PR.

Hope this is correct!

## PR Target Branch
- [x] I am targeting the `develop` branch for non-release changes.
