### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/src/apps/chifra/pkg/progress/scanbar.go
+++ b/src/apps/chifra/pkg/progress/scanbar.go
@@ -46,10 +46,7 @@ func (v *ScanBar) Report(writer io.Writer, action, msg string) {
 	}
 	width := int(float64(screenWidth()) * v.WidPct)
 	done := int(float64(width) * v.Pct())
-	remains := width - done
-	if remains < 0 {
-		remains = 0
-	}
+	remains := max(width-done, 0)
 	w := int(screenWidth()) - 2
 	x := fmt.Sprintf("%s [%s%s] %s", action, strings.Repeat(".", done), strings.Repeat(" ", remains), msg)
 	x = x[0:min(len(x), w)]


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed. -->

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.

## PR Target Branch
- [ ] I am targeting the `develop` branch for non-release changes.
