### PR TITLE
fix: prevent trace articulation parameter contamination across function calls

### DIFF
--- a/src/apps/chifra/pkg/articulate/trace.go
+++ b/src/apps/chifra/pkg/articulate/trace.go
@@ -49,11 +49,14 @@ func articulateTrace(trace *types.Trace, abiMap *abi.SelectorSyncMap) (articulat
 	}
 
 	encoding := input[:10]
-	articulated = abiMap.GetValue(encoding)
+	found := abiMap.GetValue(encoding)
 
-	if trace.Result == nil || articulated == nil {
+	if trace.Result == nil || found == nil {
 		return
 	}
+
+	// Clone the function to avoid modifying the cached instance
+	articulated = found.Clone()
 
 	var abiMethod *goEthAbi.Method
 


### PR DESCRIPTION
## Summary
- Fixed a bug where trace articulation was contaminating parameter values across different function calls
- The issue occurred because the articulation was modifying the shared Function instance from the ABI cache
- Added cloning of the function before articulation to ensure each trace gets its own instance

## Test plan
- [x] Verified that `chifra traces 0x417b981ca205d29dc16c132ab7ee3d634c195d967488810da8e3d9c86b0afb24 --articulate` now shows correct parameters for all function calls
- [x] Confirmed that each `updateStrategyDebtRatio` call now shows unique and correct parameter values
- [x] Tested that the "length insufficient" error from `multiSend` function is properly handled

🤖 Generated with [Claude Code](https://claude.ai/code)