### PR TITLE
Fix token decimal handling in ToFloatString (fixes #3915)

### DIFF
--- a/src/apps/chifra/pkg/base/types_wei.go
+++ b/src/apps/chifra/pkg/base/types_wei.go
@@ -251,13 +251,19 @@ func (w *Wei) MarshalCache(writer io.Writer) error {
 }
 
 func (w *Wei) ToFloatString(decimals int) string {
-	return ToFloat(w).Text('f', -1*decimals)
+	return ToFloatWithDecimals(w, decimals).Text('f', -1*decimals)
 }
 
 func ToFloat(wei *Wei) *Float {
+	return ToFloatWithDecimals(wei, 18)
+}
+
+func ToFloatWithDecimals(wei *Wei, decimals int) *Float {
 	f := NewFloat(0)
-	e := NewFloat(1e18)
-	return f.Quo(new(Float).SetRawWei(wei), e)
+	// Calculate 10^decimals as the divisor
+	divisorInt := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(decimals)), nil)
+	divisor := (*Float)(new(big.Float).SetInt(divisorInt))
+	return f.Quo(new(Float).SetRawWei(wei), divisor)
 }
 
 func BiFromBn(bn Blknum) *big.Int {

--- a/src/apps/chifra/pkg/base/types_wei_test.go
+++ b/src/apps/chifra/pkg/base/types_wei_test.go
@@ -581,3 +581,95 @@ func TestWeiNil(t *testing.T) {
 		})
 	}
 }
+
+func TestToFloatStringWithDecimals(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    *Wei
+		decimals int
+		expected string
+	}{
+		{
+			name:     "ETH with 18 decimals",
+			value:    NewWei(1000000000000000000), // 1 ETH
+			decimals: 18,
+			expected: "1",
+		},
+		{
+			name:     "USDC with 6 decimals - example from issue",
+			value:    NewWei(7500000000), // 7,500 USDC (raw)
+			decimals: 6,
+			expected: "7500",
+		},
+		{
+			name:     "Token with 0 decimals",
+			value:    NewWei(1000),
+			decimals: 0,
+			expected: "1000",
+		},
+		{
+			name:     "Token with 8 decimals",
+			value:    NewWei(100000000), // 1 token
+			decimals: 8,
+			expected: "1",
+		},
+		{
+			name:     "Small value with 18 decimals",
+			value:    NewWei(1), // 1 wei
+			decimals: 18,
+			expected: "0.000000000000000001",
+		},
+		{
+			name:     "Large value with 6 decimals",
+			value:    NewWei(123456789012), // 123,456.789012 USDC
+			decimals: 6,
+			expected: "123456.789012",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.value.ToFloatString(tt.decimals)
+			if result != tt.expected {
+				t.Errorf("ToFloatString(%d) = %s, want %s", tt.decimals, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestToFloatWithDecimals(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    *Wei
+		decimals int
+		expected string
+	}{
+		{
+			name:     "ETH with 18 decimals",
+			value:    NewWei(1000000000000000000), // 1 ETH
+			decimals: 18,
+			expected: "1",
+		},
+		{
+			name:     "USDC with 6 decimals",
+			value:    NewWei(1000000), // 1 USDC
+			decimals: 6,
+			expected: "1",
+		},
+		{
+			name:     "Token with different decimals",
+			value:    NewWei(100000000), // 1 token with 8 decimals
+			decimals: 8,
+			expected: "1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ToFloatWithDecimals(tt.value, tt.decimals).Text('f', -1)
+			if result != tt.expected {
+				t.Errorf("ToFloatWithDecimals(%d) = %s, want %s", tt.decimals, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This PR fixes issue #3915 where `chifra tokens` displays incorrect balances for tokens with decimals other than 18.

## Problem

The `ToFloat` function was hardcoded to use `1e18` as the divisor, which assumes all tokens have 18 decimals. This caused incorrect display for tokens like USDC (6 decimals).

Example from the issue:
- Token: USDC (6 decimals)
- Raw balance: 7,500,000,000
- Expected: 7500 USDC
- Actual (before fix): 0.0000000075

## Solution

1. Created a new `ToFloatWithDecimals` function that accepts a decimals parameter and calculates the correct divisor as `10^decimals`
2. Modified `ToFloatString` to use `ToFloatWithDecimals` instead of the hardcoded `ToFloat`
3. Kept the original `ToFloat` function for backward compatibility (defaults to 18 decimals for ETH)

## Changes

- Modified `types_wei.go`:
  - `ToFloatString` now calls `ToFloatWithDecimals` with the provided decimals
  - Added `ToFloatWithDecimals` function that properly handles custom decimal places
  - `ToFloat` now calls `ToFloatWithDecimals` with 18 decimals for backward compatibility

- Added comprehensive tests in `types_wei_test.go`:
  - Tests for various decimal places (0, 6, 8, 18)
  - Specific test for the USDC example from the issue
  - Tests for both `ToFloatString` and `ToFloatWithDecimals`

## Testing

Added unit tests that verify:
- USDC (6 decimals): 7,500,000,000 → "7500" ✓
- ETH (18 decimals): 1,000,000,000,000,000,000 → "1" ✓
- Token with 0 decimals: 1000 → "1000" ✓
- Token with 8 decimals: 100,000,000 → "1" ✓

## Impact

This fix ensures that all ERC-20 tokens display their balances correctly according to their specific decimal configuration, not just tokens with 18 decimals.

Fixes #3915

🤖 Generated with [Claude Code](https://claude.ai/code)