### PR TITLE
chore: fix typos

### DIFF
--- a/docs/content/chifra/chaindata.md
+++ b/docs/content/chifra/chaindata.md
@@ -321,7 +321,7 @@ Links:
 
 The `--traces` option requires your node to enable the `trace_block` (and related) RPC endpoints. Many remote RPC providers do not enable these endpoints due to the additional load they can place on the node. If you are running your own node, you can enable these endpoints by adding `trace` to your node's startup.
 
-The test for tracing assumes your node provides tracing starting at block 1. If your is partially synced, you may export the following enviroment variable before running the command to instruct `chifra` where to test.
+The test for tracing assumes your node provides tracing starting at block 1. If your is partially synced, you may export the following environment variable before running the command to instruct `chifra` where to test.
 
 ```[bash]
 export TB_<chain>_FIRSTTRACE=<bn>

--- a/docs/content/chifra/configs.md
+++ b/docs/content/chifra/configs.md
@@ -71,7 +71,7 @@ the table below for the name of each tool's config file.
 
 ## Multichain
 
-If you're running against mutliple chains, you may place any of these files in the root of the
+If you're running against multiple chains, you may place any of these files in the root of the
 chain's configuration folder, and the values found there will replace any values found at the
 top level. In this way, you may configure all chains for certain values, but customize your
 configuration per chain.

--- a/docs/content/chifra/globals.md
+++ b/docs/content/chifra/globals.md
@@ -78,7 +78,7 @@ Where:
 
 ### Group 4
 
-**As of version 2.6.0, the `--raw` option has been removed in  its entirity.
+**As of version 2.6.0, the `--raw` option has been removed in its entirety.
 Prior to that version, the following tools had this option which would pass
 the data received directly from the node without modification.**
 


### PR DESCRIPTION
## Description

Corrected misspellings:
- `enviroment` → `environment`
- `mutliple` → `multiple`
- `entirity` → `entirety`
