### PR TITLE
chore: Fix typos

### DIFF
--- a/docs/content/blog/2017/016-Is-the-Ice-Age-Affecting-Block-Production.md
+++ b/docs/content/blog/2017/016-Is-the-Ice-Age-Affecting-Block-Production.md
@@ -12,7 +12,7 @@ weight: 984
 
 This is just one of 100’s of questions we have about what is happening on the Ethereum blockchain. We’re developing TrueBlocks to help us answer these questions and more.
 
-[TrueBlocks](https://github.com/TrueBlocks/trueblocks-core) is a set of software libraries, applications, and command line tools that provide fast, easy, fully-decentralized access to the Ethereum blockchain data. As part of preparing for our next release, we’ve written a a number of simple command line tools to test our code. One of these is called `whenBlock` which helped us answer the question above.
+[TrueBlocks](https://github.com/TrueBlocks/trueblocks-core) is a set of software libraries, applications, and command line tools that provide fast, easy, fully-decentralized access to the Ethereum blockchain data. As part of preparing for our next release, we've written a number of simple command line tools to test our code. One of these is called `whenBlock` which helped us answer the question above.
 
 Here’s the help screen from `whenBlock`:
 

--- a/docs/content/chifra/globals.md
+++ b/docs/content/chifra/globals.md
@@ -93,7 +93,7 @@ chifra slurp
 
 ### Group 5
 
-This final group of tools do not produce any real data. They are mostly used for configuration and/or to start and stop long-running processes. They allow no additional options over the default, but disable the following options depending on context. The `deamon` option, which provides all the tools via a local API, disables `--chain` because one sends chain with the URL.
+This final group of tools do not produce any real data. They are mostly used for configuration and/or to start and stop long-running processes. They allow no additional options over the default, but disable the following options depending on context. The `daemon` option, which provides all the tools via a local API, disables `--chain` because one sends chain with the URL.
 
 | Group | Cmd     | Enabled | Disabled                                   |
 | ----- | ------- | ------- | ------------------------------------------ |

--- a/docs/content/data-model/admin.md
+++ b/docs/content/data-model/admin.md
@@ -106,7 +106,7 @@ ChunkRecords consist of the following fields:
 ## ChunkIndex
 
 The `indexchunk` data model represents internal information about each Unchained Index index chunk.
-It is used mostly interenally to study the characteristics of the Unchained Index.
+It is used mostly internally to study the characteristics of the Unchained Index.
 
 The following commands produce and manage ChunkIndexes:
 
@@ -165,7 +165,7 @@ ChunkAddress consist of the following fields:
 | address    | the address in this record                                                | address                                     |
 | range      | the block range of the chunk from which this address record was taken     | blkrange                                    |
 | offset     | the offset into the appearance table of the first record for this address | uint64                                      |
-| count      | the number of records in teh appearance table for this address            | uint64                                      |
+| count      | the number of records in the appearance table for this address            | uint64                                      |
 | rangeDates | if verbose, the block and timestamp bounds of the chunk (may be null)     | [RangeDates](/data-model/admin/#rangedates) |
 
 ## IpfsPin

--- a/src/dev_tools/goMaker/README.md
+++ b/src/dev_tools/goMaker/README.md
@@ -64,7 +64,7 @@ The `.toml` file contains the following fields:
 
 | Name         | Description                                                                      | Notes                                                                                        |
 | ------------ | -------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| class        | the name of teh data model in lower case                                         |                                                                                              |
+| class        | the name of the data model in lower case                                         |                                                                                              |
 | contained_by | if this data model is contained by other models, the list of other models        |                                                                                              |
 | doc_group    | corresponds the subcommand's group for documentation purposes                    |                                                                                              |
 | doc_route    | corresponds to the subsection of the data model documentation for this type      | poorly named                                                                                 |


### PR DESCRIPTION
Fixes clear spelling and punctuation errors:

  - deamon → daemon
  - interenally → internally
  - teh → the
  - we’ve → we've (normalize apostrophes for consistency)
