### PR TITLE
fix(docs): amend spelling issues in docs & README content.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 Repo for the [TrueBlocks.io website](https://trueblocks.io).
 
-Note: There is only a `main` branch which is protected. Make any PRs against this branch and we will review and merge if approriate.
+Note: There is only a `main` branch which is protected. Make any PRs against this branch and we will review and merge if appropriate.
 
 ## Contributing to the docs
 

--- a/docs/config/_default/menus.toml
+++ b/docs/config/_default/menus.toml
@@ -56,9 +56,9 @@
     url = "/sdks/introduction"
     weight = 10
 [[sdks]]
-    identifier = "langauges"
-    name = "Langauges"
-    url = "/sdks/langauges"
+    identifier = "languages"
+    name = "Languages"
+    url = "/sdks/languages"
     weight = 20
 
 [[main]]

--- a/docs/content/chifra/admin.md
+++ b/docs/content/chifra/admin.md
@@ -168,7 +168,7 @@ Links:
 To convert the options for a command line tool to an API call, do the following:
 
 1. Any `--snake_case` argument to the command line should be converted to `camelCase`. For example, `--no_header` on the command line should be sent as `&noHeader` to the API server.
-2. Any `switch` on the command line, (i.e., options whose presence indicates `true` and whose absence indicates `false`) should be sent as a `boolean` to the API server. For example, `--no_header` on the command line should be sent as `&noHeader=true` to the API server. If the option is `fales`, you do not need to send it to the API server.
+2. Any `switch` on the command line, (i.e., options whose presence indicates `true` and whose absence indicates `false`) should be sent as a `boolean` to the API server. For example, `--no_header` on the command line should be sent as `&noHeader=true` to the API server. If the option is `false`, you do not need to send it to the API server.
 3. Positionals such as the addresses, topics, and four-bytes for `chifra export`, must be prepended with their positional name. For example, `chifra export <address> <topic>` should be sent as `&addrs=<address>&topics=<topic>` to the API server. For some commands (experiment) you may send more than one value for a positional with `%20` separating the entries or by sending multiple positionals (i.e., `&addrs=<address1>&addrs=<address2>`).
 
 <hr />
@@ -278,7 +278,7 @@ while imposing a minimum amount of resource requirement on the end user's machin
 Recently, we enabled the ability for the end user to pin these downloaded index chunks and blooms
 on their own machines. The user needs the data for the software to operate--sharing requires
 minimal effort and makes the data available to other people. Everyone is better off. A
-naturally-occuring network effect.
+naturally-occurring network effect.
 
 ### tracing
 

--- a/docs/content/chifra/configs.md
+++ b/docs/content/chifra/configs.md
@@ -56,7 +56,7 @@ A single global configuration, called `trueBlocks.toml`, which stores all the co
 
 Note: As of version 2.5.2, this is no longer true.
 
-In addition, each individual tool may have its own configuration file with items peculuar to that tool.
+In addition, each individual tool may have its own configuration file with items peculiar to that tool.
 If a configuration item is found in a particular file, it applies only to that tool.
 
 If, however, one of the items documented below under `trueBlocks.toml` is found in a tool's

--- a/docs/content/chifra/globals.md
+++ b/docs/content/chifra/globals.md
@@ -89,7 +89,7 @@ chifra slurp
 
 ### Group 5
 
-This final group of tools do not produce any real data. They are mostly used for configuration and/or to start and stop long-running processes. They allow no additional options over the default, but disable the following options depending on context. The `deamon` option, which provides all the tools via a local API, disables `--chain` because one sends chain with the URL.
+This final group of tools do not produce any real data. They are mostly used for configuration and/or to start and stop long-running processes. They allow no additional options over the default, but disable the following options depending on context. The `daemon` option, which provides all the tools via a local API, disables `--chain` because one sends chain with the URL.
 
 | Group | Cmd     | Enabled | Disabled                                   |
 | ----- | ------- | ------- | ------------------------------------------ |

--- a/docs/content/data-model/accounts.md
+++ b/docs/content/data-model/accounts.md
@@ -61,7 +61,7 @@ Appearances consist of the following fields:
 A Monitor is a list of [Appearances](/data-model/accounts/#appearance) associated with a given
 address along with various details about those appearances. A monitor is created when a user
 expresses interest in an address by calling either [chifra list](/chifra/accounts/#chifra-list)
-or [chifra export](/chifra/accounts/#chifra-export) tool (or querying thier associated APIs).
+or [chifra export](/chifra/accounts/#chifra-export) tool (or querying their associated APIs).
 
 Once created, a monitor may be periodically *freshened* by calling either `chifra list` or `chifra
 export`, however, it is also possible to freshen a monitor continually with
@@ -217,7 +217,7 @@ Statements consist of the following fields:
 
 ## Transfer
 
-The Transfer type is used by the Reconcilation type to represent any transfer of an asset from one account to another.
+The Transfer type is used by the Reconciliation type to represent any transfer of an asset from one account to another.
 
 The following commands produce and manage Transfers:
 

--- a/docs/content/data-model/chaindata.md
+++ b/docs/content/data-model/chaindata.md
@@ -199,7 +199,7 @@ Traces consist of the following fields:
 
 ### Notes
 
-Traces and TraceActions, when produced during a self-destruct, export different fields when rendered in JSON. In CSV and TXT output, these fields change thier meaning while retaining the header of the original fields. The following table describes these differences:
+Traces and TraceActions, when produced during a self-destruct, export different fields when rendered in JSON. In CSV and TXT output, these fields change their meaning while retaining the header of the original fields. The following table describes these differences:
 
 Fields that change during self-destruct transaction:
 

--- a/docs/content/data-model/intro.md
+++ b/docs/content/data-model/intro.md
@@ -18,7 +18,7 @@ toc: true
 
 ## TrueBlocks data
 
-On its own blockchain data is an unintelligable blob of binary bytes. But, we all know there
+On its own blockchain data is an unintelligible blob of binary bytes. But, we all know there
 is an amazing collection of deeply interesting information contained therein. Thousands of
 people are trading, voting, expressing their preferences, making markets for valueless
 items every minute.

--- a/docs/content/data-model/the-index.md
+++ b/docs/content/data-model/the-index.md
@@ -25,7 +25,7 @@ to point out that the Unchained Index:
 - Allows perfectly-private access to query blockchain data completely locally
 - Naturally shards itself and distributes itself using IPFS and user behaviour
 - Is published periodically to a smart contract and once published cannot be removed from public use
-- Is reproducable directly from immutable data with a well-defined series of operations meaning its as immutable as the original blockchain data
+- Is reproducible directly from immutable data with a well-defined series of operations meaning its as immutable as the original blockchain data
 - Compact
 - Digs deeper into the blockchain than any other source allowing for instantaneous, 18-decimal-place accurate off-chain reconciliation of any account
 - Blazingly fast

--- a/docs/content/docs/install/build-unchained-index.md
+++ b/docs/content/docs/install/build-unchained-index.md
@@ -102,7 +102,7 @@ For detailed instructions, see the [`chifra scrape` command documentation](/chif
 
 **How it works**:
 
-The end result of `chifa scrape` is the same as the end result of `chifra init --all`. However, the process is crucially different: rather than downloading the index that we publish (that is, trusting us), `chifra scrape` _builds the index on your local machine connecting only with your local-running RPC endpoint_, which means if you trust your own setup, you can trust the data.
+The end result of `chifra scrape` is the same as the end result of `chifra init --all`. However, the process is crucially different: rather than downloading the index that we publish (that is, trusting us), `chifra scrape` _builds the index on your local machine connecting only with your local-running RPC endpoint_, which means if you trust your own setup, you can trust the data.
 
 (One note: It's possible to run against any RPC endpoint -- remote or local -- but because the TrueBlocks scraper hits the node continually and very aggressively, you will probably get rate-limited against a shared RPC server such as Infura.)
 

--- a/docs/content/faq/_index.md
+++ b/docs/content/faq/_index.md
@@ -65,7 +65,7 @@ Note this only works for non-CEX addresses which must be handled separately and 
 
 It's faster, cheaper, uncensorable, and private.
 
-**Faster:** You can hit your own RPC endpoints as fast as you could possible want. No rate limiting. It's surprsing how important this is. It transforms a "difficult-to-use node" into a perfectly fine data server.
+**Faster:** You can hit your own RPC endpoints as fast as you could possible want. No rate limiting. It's surprising how important this is. It transforms a "difficult-to-use node" into a perfectly fine data server.
 
 **Cheaper:** Over time, it's way, way cheaper to run your own infrastructure. There's only a single initial capital outlay. Plus -- you don't need a huge memory machine. Once the node and our scraper are caught up to the front of the chain, there's only a single block at every so many seconds. This is easily handled for both the local node and TrueBlocks. More memory is better, of course, but is also not the main bottleneck. (In fact, there are no bottlenecks--they system is mostly waiting for new blocks from the network.)
 
@@ -127,13 +127,13 @@ Here's what these numbers mean:
 | block     | meaning                                                                            | distance<br>from head | configurable | will be<br>revisited |
 | --------- | ---------------------------------------------------------------------------------- | --------------------- | ------------ | -------------------- |
 | latest    | The latest block on the chain. Same as `eth_getBlockByNumber('latest').            | 0 blocks              | -            | -                    |
-| finalized | The last block that has been consilidated into a "chunk". (i.e. an index portion). | depends               | **yes**      | no                   |
+| finalized | The last block that has been consolidated into a "chunk". (i.e. an index portion). | depends               | **yes**      | no                   |
 | staging   | The latest block "on the stage". (i.e. awaiting inclusion in the next chunk).      | depends               | **yes**      | no                   |
 | ripe      | Blocks that have been scraped, but not yet staged.                                 | 28 blocks             | **yes**      | no                   |
 | unripe    | Blocks that are "too close to the head" to be reliable.                            | 0 blocks              | no           | **yes**              |
 | timestamp | The latest scraped timestamp (used for debugging).                                 | n/a                   | -            | no                   |
 
-For a much better explaination of these numbers (and more generally the scraper), please see the [TrueBlocks Spec](https://trueblocks.io/papers/2022/file-format-spec-v0.40.0-beta.pdf).
+For a much better explanation of these numbers (and more generally the scraper), please see the [TrueBlocks Spec](https://trueblocks.io/papers/2022/file-format-spec-v0.40.0-beta.pdf).
 
 #### -- I'm getting an error message: current file does not sequentially follow previous file. What do?
 
@@ -207,19 +207,19 @@ When you do chifra export (without --unripe) you get both types, so you're alway
 
 Does that help?
 
-The Magizine Model
+The Magazine Model
 
 Magazines have exactly the same qualities as immutable data. They publish periodically. They cannot go back and correct
 something previously published. They publish in chunks (issue) and collect those issues in volumes (manifests) and make
 corrections via errata. And can be indexed and sliced and diced.
 
-We should study the library science of magizine publishing. How do librarians organize magazines? How do magizines
+We should study the library science of magazine publishing. How do librarians organize magazines? How do magazines
 organize themselves.
 
-We should change our code to reflect this and suggest to the guy who's doing the EIPs that he use the magizine metaphor
+We should change our code to reflect this and suggest to the guy who's doing the EIPs that he use the magazine metaphor
 over the book metaphor. Books are multi-chapter, but they are not published periodically.
 
-We can offer Uniswap a magizine publishing model (and it should not escape our notice that magizines have subscribers).
+We can offer Uniswap a magazine publishing model (and it should not escape our notice that magazines have subscribers).
 
 They can:
 

--- a/docs/content/sdks/introduction.md
+++ b/docs/content/sdks/introduction.md
@@ -20,10 +20,10 @@ This has very significant performance implications because there is no serializa
 server case, the code must read the data from the RPC (or the local binary cache), turn it into a JSON string,
 and send it to the TypeScript or Python SDK. 
 
-In the GoLang SDK, the data is in memory ready for use directly from disc. No strinification. This makes the
+In the GoLang SDK, the data is in memory ready for use directly from disk. No stringification. This makes the
 GoLang SDK as fast as it can possibly be.
 
-The two API-releated SDKs are the [TypeScript SDK](/sdks/typescript-sdk/) and the [Python SDK](/sdks/python-sdk/).
+The two API-related SDKs are the [TypeScript SDK](/sdks/typescript-sdk/) and the [Python SDK](/sdks/python-sdk/).
 
 The GoLang SDKs is here [GoLang SDK](/sdks/go-sdk/).
 

--- a/docs/content/tutorials/_index.md
+++ b/docs/content/tutorials/_index.md
@@ -30,7 +30,7 @@ We hope to show why:
 - The RPC is broken, but it can be fixed,
 - Web 2.0 APIs delivering Web 3.0 data makes NO SENSE!
   - Rate limiting slows the world to molasses,
-  - Thier non-standard endpoints will capture you,
+  - Their non-standard endpoints will capture you,
   - They MUST know who you are so they can rate limit you,
   - The API game is winner-take-all. Witness Google,
   - How do we know they're not lying?

--- a/docs/content/tutorials/step1.md
+++ b/docs/content/tutorials/step1.md
@@ -24,7 +24,7 @@ Progress:          4259662, 0, 0, 0 ts: 4438781
 
 1. The paths listed in the middle of the output may come in handy for configuration.
 2. The final line shows five numbers:
-   - The first number is the lastest block on the chain.
+   - The first number is the latest block on the chain.
    - The last number is the latest timestamps (this was downloaded).
    - The three middle numbers are related to the index. Ignore them for now.
 
@@ -42,7 +42,7 @@ Run this command which displays the current state of the index. It will report a
 chifra chunks blooms
 ```
 
-This makes sense. It's telling you that you've not yet initalized the system. It suggests either `chifra init` or `chifra scrape`. Let's try `chifra scrape`.
+This makes sense. It's telling you that you've not yet initialized the system. It suggests either `chifra init` or `chifra scrape`. Let's try `chifra scrape`.
 
 Run:
 

--- a/docs/content/tutorials/step2.md
+++ b/docs/content/tutorials/step2.md
@@ -44,7 +44,7 @@ This is every receipt (or log, or transaction, or trace if you have a tracing no
 
 ### Getting rate limited
 
-How about a block with a lot of transacitons? Try this:
+How about a block with a lot of transactions? Try this:
 
 ```bash
 chifra blocks 4100000 --uniq --cache --cache_txs --cache_traces
@@ -56,7 +56,7 @@ chifra blocks 4100000 --uniq --cache --cache_txs --cache_traces
 
 ----
 
-**Important:** If you get rate limited, don't run the command again. They may cut you off permenantly.
+**Important:** If you get rate limited, don't run the command again. They may cut you off permanently.
 
 Did you get rate limited? We didn't.
 

--- a/docs/content/tutorials/step3.md
+++ b/docs/content/tutorials/step3.md
@@ -9,7 +9,7 @@ draft: false
 
 Let's dig deeper. Let's query specific addresses. In other words, snoop.
 
-**Note:** chances are very high that if you're not running your own node, you will get rate limted with these commands.
+**Note:** chances are very high that if you're not running your own node, you will get rate limited with these commands.
 
 Do this:
 
@@ -34,7 +34,7 @@ Note how slow this is (TrueBlocks is a work in progress).
 chifra state --no_header --ether --chain mainnet --file grants.txt
 ```
 
-A bit slow, but this is the current ether balance of each of the grant receipients. I don't know about you, all other things equal, I'd give to a project with a smaller balance than an larger one. Even if only because they're smart enough to drain thier wallet.
+A bit slow, but this is the current ether balance of each of the grant recipients. I don't know about you, all other things equal, I'd give to a project with a smaller balance than an larger one. Even if only because they're smart enough to drain their wallet.
 
 Notice four other things with this command:
 
@@ -45,15 +45,15 @@ Notice four other things with this command:
 
 ### Getting Token Balances
 
-We leave this part of the tutorial as an excercise. Run `chifra tokens`. Read the help text. Figure out how to get token balances for each of the grant receipients for any token, but here's a hint:
+We leave this part of the tutorial as an exercise. Run `chifra tokens`. Read the help text. Figure out how to get token balances for each of the grant recipients for any token, but here's a hint:
 
-The holdings as the latest block for each of the grants receipients for the DAI stable coin:
+The holdings as the latest block for each of the grants recipients for the DAI stable coin:
 
 ```bash
 chifra names dai stable 0x6 -s | chifra tokens --no_header --chain mainnet 0x6b175474e89094c44da98b954eedeac495271d0f --file grants.txt --cache
 ```
 
-The holdings each week for each of the grants receipients for the DAI stable coin:
+The holdings each week for each of the grants recipients for the DAI stable coin:
 
 ```bash
 chifra names dai stable 0x6 -s | chifra tokens --no_header --chain mainnet 0x6b175474e89094c44da98b954eedeac495271d0f --file grants.txt --cache 14000000-15000000:weekly

--- a/src/other/migrations/README-v2.0.0.md
+++ b/src/other/migrations/README-v2.0.0.md
@@ -84,7 +84,7 @@ If `withdrawals` are available for your chain, and you know which block `withdra
 chifra chunks index --truncate <bn> --chain <chain>
 ```
 
-The above will remove all blocks prior to and including the chunk containing `bn` from your index. You may then re-run `chifar scrape` to catch back up to the head.
+The above will remove all blocks prior to and including the chunk containing `bn` from your index. You may then re-run `chifra scrape` to catch back up to the head.
 
 ### Tagging an existing index
 


### PR DESCRIPTION
## Description

Amending spelling issues across the docs and one in an old README version.

Potentially breaking `change docs/config/_default/menus.toml` L59-61